### PR TITLE
feat(template): add preview image feat in template page; 

### DIFF
--- a/server/prisma/migrations/20260611064857_add_project_preview_image/migration.sql
+++ b/server/prisma/migrations/20260611064857_add_project_preview_image/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "previewImageKey" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -125,6 +125,7 @@ model Project {
   projectStatus      ProjectStatus   @default(DRAFT)
   currentVersionId   String?
   versionCount       Int             @default(0)
+  previewImageKey    String?
 
   currentVersion ProjectVersion?  @relation("ProjectCurrentVersion", fields: [currentVersionId], references: [id])
   user           User             @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/server/src/modules/runtime/runtime.service.ts
+++ b/server/src/modules/runtime/runtime.service.ts
@@ -4,7 +4,8 @@ import {
     publishStoredPreviewManifest,
     type PreviewManifestRef,
 } from '../project/preview-manifest'
-import { getBinaryFile } from '../project/project-storage'
+import { getBinaryFile, putBinaryFile } from '../project/project-storage'
+import { chromium } from 'playwright'
 
 export type RuntimePreviewError = {
     class:
@@ -63,6 +64,100 @@ type ProjectVersionRecord = NonNullable<Awaited<ReturnType<typeof prisma.project
 const previewStatusStore = new Map<string, RuntimePreviewStatus>()
 const runtimeBaseUrl = (process.env.RUNTIME_BASE_URL ?? 'http://127.0.0.1:5050').replace(/\/+$/, '')
 const runtimeSharedSecret = process.env.RUNTIME_SHARED_SECRET
+
+const pendingDeletions = new Map<string, NodeJS.Timeout>()
+
+export function cancelPendingDeletion(projectId: string) {
+    const timer = pendingDeletions.get(projectId)
+    if (timer) {
+        clearTimeout(timer)
+        pendingDeletions.delete(projectId)
+        console.log(`[runtime] Cancelled pending 5-minute deletion for project ${projectId}`)
+    }
+}
+
+export function scheduleDeletion(projectId: string, delayMs: number) {
+    cancelPendingDeletion(projectId)
+    const timer = setTimeout(async () => {
+        try {
+            console.log(`[runtime] Deleting preview container for project ${projectId} after 5 min delay`)
+            await runtimeRequest<{ deleted: boolean }>(`/previews/${encodeURIComponent(projectId)}`, {
+                method: 'DELETE',
+            }).catch(() => null)
+            previewStatusStore.delete(projectId)
+            pendingDeletions.delete(projectId)
+        } catch (err) {
+            console.error(`Failed to delete preview container after delay for project ${projectId}:`, err)
+            pendingDeletions.delete(projectId)
+        }
+    }, delayMs)
+    pendingDeletions.set(projectId, timer)
+}
+
+async function takePreviewScreenshot(projectId: string, previewUrl: string) {
+    console.log(`[Screenshot] Starting screenshot capture workflow for project ${projectId}`)
+    console.log(`[Screenshot] Target URL: ${previewUrl}`)
+    let browser;
+    try {
+        console.log(`[Screenshot] Launching Playwright Chromium browser...`)
+        browser = await chromium.launch({
+            headless: true,
+            args: ['--no-sandbox', '--disable-setuid-sandbox']
+        })
+        console.log(`[Screenshot] Browser launched successfully.`)
+
+        console.log(`[Screenshot] Creating new browser context (Viewport: 1280x800)...`)
+        const context = await browser.newContext({
+            viewport: { width: 1280, height: 800 }
+        })
+        console.log(`[Screenshot] Browser context created.`)
+
+        console.log(`[Screenshot] Opening new browser page...`)
+        const page = await context.newPage()
+        console.log(`[Screenshot] New browser page opened.`)
+        
+        console.log(`[Screenshot] Navigating to ${previewUrl}...`)
+        await page.goto(previewUrl, { waitUntil: 'networkidle', timeout: 30000 })
+        console.log(`[Screenshot] Navigation complete. Page loaded with networkidle.`)
+        
+        console.log(`[Screenshot] Waiting 2000ms for animations and client-side rendering to settle...`)
+        await page.waitForTimeout(2000)
+        console.log(`[Screenshot] Wait complete. Capturing page screenshot as PNG...`)
+        
+        const screenshotBuffer = await page.screenshot({ type: 'png' })
+        console.log(`[Screenshot] Screenshot buffer captured. Buffer size: ${screenshotBuffer.byteLength} bytes.`)
+        
+        const key = `projects/${projectId}/preview.png`
+        console.log(`[Screenshot] Uploading screenshot to object storage (MinIO) at key: ${key}...`)
+        await putBinaryFile({
+            key,
+            content: screenshotBuffer,
+            contentType: 'image/png'
+        })
+        console.log(`[Screenshot] Screenshot uploaded to object storage successfully.`)
+        
+        console.log(`[Screenshot] Updating database for project ${projectId} with previewImageKey...`)
+        await prisma.project.update({
+            where: { id: projectId },
+            data: {
+                previewImageKey: key
+            }
+        })
+        console.log(`[Screenshot] Database updated successfully.`)
+        
+        console.log(`[Screenshot] Screenshot capture workflow completed successfully for project ${projectId}.`)
+    } catch (error) {
+        console.error(`[Screenshot] Capture workflow failed for project ${projectId}:`, error)
+    } finally {
+        if (browser) {
+            console.log(`[Screenshot] Closing browser...`)
+            await browser.close()
+            console.log(`[Screenshot] Browser closed.`)
+        }
+        console.log(`[Screenshot] Scheduling container cleanup for project ${projectId} in 5 minutes...`)
+        scheduleDeletion(projectId, 5 * 60 * 1000)
+    }
+}
 
 const parseStoredProjectFiles = (value: unknown): StoredProjectFile[] => {
     if (!Array.isArray(value)) {
@@ -218,6 +313,7 @@ const recordRuntimeStatus = (previewId: string, status: RuntimeStatusCallbackInp
 }
 
 const startPreview = async ({ userId, projectId, versionId }: StartPreviewInput) => {
+    cancelPendingDeletion(projectId)
     const { project, version } = await loadProjectVersion({ userId, projectId, versionId })
 
     if (version.status !== 'READY') {
@@ -344,11 +440,32 @@ const deletePreview = async ({ userId, previewId }: PreviewIdentifierInput) => {
         throw new Error('project not found')
     }
 
-    await runtimeRequest<{ deleted: boolean }>(`/previews/${encodeURIComponent(previewId)}`, {
-        method: 'DELETE',
-    })
+    let status: RuntimePreviewStatus | undefined
+    try {
+        status = await getPreviewStatus({ userId, previewId })
+    } catch (err) {
+        console.error('Failed to get preview status before delete:', err)
+    }
 
-    previewStatusStore.delete(previewId)
+    const hasValidPreview =
+        status &&
+        status.state === 'Healthy' &&
+        status.backendStatus === 'ready' &&
+        !status.lastError &&
+        status.previewUrl
+
+    if (hasValidPreview && status.previewUrl) {
+        // Capture screenshot in the background (which will schedule container deletion in 5 min)
+        takePreviewScreenshot(project.id, status.previewUrl).catch((err) => {
+            console.error('Unhandled error in takePreviewScreenshot:', err)
+        })
+    } else {
+        // Delete container immediately
+        await runtimeRequest<{ deleted: boolean }>(`/previews/${encodeURIComponent(previewId)}`, {
+            method: 'DELETE',
+        }).catch(() => null)
+        previewStatusStore.delete(previewId)
+    }
 
     return {
         deleted: true,

--- a/server/src/modules/template/template.controller.ts
+++ b/server/src/modules/template/template.controller.ts
@@ -229,6 +229,27 @@ const getTemplatePreviewHtml = async (req: Request, res: Response) => {
     }
 }
 
+const getTemplatePreviewImage = async (req: Request, res: Response) => {
+    const templateId = req.params.templateId as string | undefined
+
+    if (!templateId) {
+        return res.status(400).send('templateId is required')
+    }
+
+    try {
+        const imageBuffer = await templateService.getTemplatePreviewImage(templateId)
+        if (!imageBuffer) {
+            return res.status(404).send('preview image not found')
+        }
+        res.setHeader('Content-Type', 'image/png')
+        return res.status(200).send(imageBuffer)
+    } catch (error: any) {
+        return res
+            .status(error instanceof AppError ? error.statusCode : 500)
+            .send('failed to load preview image')
+    }
+}
+
 export const templateController = {
     getAllTemplates,
     getTemplateById,
@@ -236,4 +257,5 @@ export const templateController = {
     remixTemplate,
     toggleLike,
     getTemplatePreviewHtml,
+    getTemplatePreviewImage,
 }

--- a/server/src/modules/template/template.routes.ts
+++ b/server/src/modules/template/template.routes.ts
@@ -6,6 +6,7 @@ import { templateController } from './template.controller'
 const templateRouter = Router()
 
 templateRouter.get('/:templateId/preview.html', templateController.getTemplatePreviewHtml)
+templateRouter.get('/:templateId/preview.png', templateController.getTemplatePreviewImage)
 templateRouter.use(authMiddleware)
 templateRouter.get('/', templateController.getAllTemplates)
 templateRouter.get('/featured', templateController.getFeaturedTemplates)

--- a/server/src/modules/template/template.service.ts
+++ b/server/src/modules/template/template.service.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto'
 
 import { prisma } from '../../config/db'
+import { getBinaryFile } from '../project/project-storage'
 import { saveProjectFiles } from '../project/save-project-files'
 import { AppError } from '../../shared/appError'
 import { hydrateCanvasDocument, persistCanvasDocument } from '../canvas/canvas.persistence'
@@ -35,6 +36,7 @@ type TemplateWithLikeMeta = {
     authorUsername: string
     likeCount: number
     isLiked: boolean
+    previewImageKey?: string | null
 }
 
 const mapTemplateWithLikeMeta = (
@@ -49,6 +51,7 @@ const mapTemplateWithLikeMeta = (
         createdAt: Date
         updatedAt: Date
         userId: string
+        previewImageKey: string | null
         user: {
             name: string
             username: string
@@ -78,6 +81,7 @@ const mapTemplateWithLikeMeta = (
         authorUsername: template.user.username,
         likeCount,
         isLiked: viewerLike?.isLiked ?? false,
+        previewImageKey: template.previewImageKey,
     }
 }
 
@@ -101,6 +105,7 @@ const getAllTemplates = async (userId?: string) => {
                 createdAt: true,
                 updatedAt: true,
                 userId: true,
+                previewImageKey: true,
                 user: {
                     select: {
                         name: true,
@@ -145,6 +150,7 @@ const getTemplateById = async (data: string | { userId: string; templateId: stri
             createdAt: true,
             updatedAt: true,
             userId: true,
+            previewImageKey: true,
             user: {
                 select: {
                     name: true,
@@ -192,6 +198,7 @@ const getFeaturedTemplates = async (userId?: string) => {
                 createdAt: true,
                 updatedAt: true,
                 userId: true,
+                previewImageKey: true,
                 user: {
                     select: {
                         name: true,
@@ -496,6 +503,28 @@ const getTemplatePreviewHtml = async (templateId: string) => {
     return documentHtml
 }
 
+const getTemplatePreviewImage = async (templateId: string) => {
+    const template = await prisma.project.findFirst({
+        where: { id: templateId, isSharedAsTemplate: true },
+        select: { id: true, previewImageKey: true },
+    })
+
+    if (!template) {
+        throw new AppError('template not found', 404)
+    }
+
+    if (!template.previewImageKey) {
+        return null
+    }
+
+    const file = await getBinaryFile(template.previewImageKey)
+    if (!file) {
+        return null
+    }
+
+    return Buffer.from(file.body)
+}
+
 export const templateService = {
     getAllTemplates,
     getTemplateById,
@@ -503,4 +532,5 @@ export const templateService = {
     remixTemplate,
     toggleLike,
     getTemplatePreviewHtml,
+    getTemplatePreviewImage,
 }

--- a/web/src/features/templates/api/template.ts
+++ b/web/src/features/templates/api/template.ts
@@ -16,6 +16,7 @@ export type BackendTemplate = {
     authorUsername: string
     likeCount: number
     isLiked: boolean
+    previewImageKey?: string | null
 }
 
 type ToggleLikeResult = {

--- a/web/src/features/templates/components/TemplateCard.tsx
+++ b/web/src/features/templates/components/TemplateCard.tsx
@@ -32,15 +32,32 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
         <div className="group flex flex-col gap-3.5 cursor-pointer w-full">
             {/* Image Container */}
             <div className="relative aspect-[16/10] bg-[#111] overflow-hidden rounded-xl border border-[#242323] transition-all duration-300">
-                <div className="absolute w-[300%] h-[300%] origin-top-left scale-[0.333333] transition-transform duration-700 ease-[0.25,1,0.5,1] group-hover:scale-[0.34]">
-                    <iframe
-                        src={`${API_BASE_URL}/template/${template.id}/preview.html`}
-                        title={template.title}
-                        className="w-full h-full border-0 pointer-events-none select-none bg-white"
+                {template.previewImageKey ? (
+                    <img
+                        src={`${API_BASE_URL}/template/${template.id}/preview.png`}
+                        alt={template.title}
+                        className="w-full h-full object-cover transition-transform duration-700 ease-[0.25,1,0.5,1] group-hover:scale-[1.04]"
                         loading="lazy"
-                        sandbox="allow-scripts allow-same-origin"
                     />
-                </div>
+                ) : (
+                    <div className="w-full h-full flex flex-col items-center justify-center bg-gradient-to-br from-[#FAF9F6] to-[#F3F2EE] select-none p-4 text-center">
+                        <svg
+                            className="w-7 h-7 mb-2 text-[#8C8B86] opacity-90 stroke-[1.5]"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+                            <circle cx="9" cy="9" r="2" />
+                            <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+                        </svg>
+                        <span className="text-[12px] font-medium text-[#6B6964] tracking-tight">
+                            No preview available
+                        </span>
+                    </div>
+                )}
 
                 {/* Soft bottom gradient for depth */}
                 <div className="absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/60 to-transparent pointer-events-none opacity-60"></div>

--- a/web/src/features/templates/types.ts
+++ b/web/src/features/templates/types.ts
@@ -20,6 +20,7 @@ export type Template = {
     createdAt: string
     updatedAt: string
     isFeatured: boolean
+    previewImageKey?: string | null
 }
 
 const mapProjectCategory = (projectCategory: string): TemplateCategory => {
@@ -50,4 +51,5 @@ export const mapBackendTemplateToTemplate = (template: BackendTemplate): Templat
     createdAt: template.createdAt,
     updatedAt: template.updatedAt,
     isFeatured: template.isFeatured,
+    previewImageKey: template.previewImageKey,
 })


### PR DESCRIPTION
- take screenhsot by bg worker
- store in obj store
- render the image in template card

<img width="1089" height="572" alt="Screenshot 2026-06-11 124840" src="https://github.com/user-attachments/assets/4e8d96aa-a061-47fb-a900-048673b371b5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Template cards now display preview images instead of embedded previews, with a placeholder shown when no preview is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->