### PR TITLE
feat(cli): refactor settings, enforce sandboxing and tasks mode (#298)

### DIFF
--- a/.december/AGENTS.md
+++ b/.december/AGENTS.md
@@ -1,3 +1,1 @@
 # AGENTS.md
-
-Welcome to December workspace instructions. December automatically loads project context, coding rules, and available agent skills from `.december/`.

--- a/.december/mcp.json
+++ b/.december/mcp.json
@@ -1,3 +1,9 @@
 {
-    "mcpServers": {}
+    "mcpServers": {
+        // Add your Model Context Protocol (MCP) servers here
+        // "example-server": {
+        //   "command": "node",
+        //   "args": ["path/to/server.js"]
+        // }
+    }
 }

--- a/.december/rules.md
+++ b/.december/rules.md
@@ -1,6 +1,1 @@
 # Rules
-
-- **Code Quality**: Ensure all functions have proper TypeScript typing and descriptive parameter names.
-- **Error Handling**: Never use empty catch blocks; always handle or explicitly log exceptions.
-- **Testing**: Write unit or integration tests for new services and run test suites before submitting changes.
-- **Architecture**: Keep business logic inside service modules and delegate HTTP request parsing to controllers.

--- a/.december/settings.json
+++ b/.december/settings.json
@@ -1,4 +1,0 @@
-{
-    "thinkingLevel": "low",
-    "steeringMode": "all"
-}

--- a/.december/skills.md
+++ b/.december/skills.md
@@ -1,6 +1,1 @@
 # Skills
-
-- **Code Review**: Autonomous code review checking coding standards and architectural requirements.
-- **Refactoring**: Step-by-step code refactoring with incremental safety checks and clean commits.
-- **Bug Diagnosis**: Systematic root cause investigation using log tracebacks and regression tests.
-- **Test Generation**: Automated generation of unit and integration test suites using red-green-refactor patterns.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,3 +39,11 @@ A step-by-step event log (`trajectory.jsonl`) generated during an evaluation run
 ## EvalReport
 
 A structured summary report (`summary.json`) produced at the conclusion of an evaluation suite run. Contains aggregate metrics including pass rates (Pass@1), total execution duration, token usage totals, and cost metrics.
+
+## PrReview
+
+An AI-generated code review for a GitHub Pull Request executed inside an ephemeral E2B sandbox. Contains review status (`PENDING`, `COMPLETED`, `FAILED`), overall summary markdown, GitHub review event (`COMMENT`, `REQUEST_CHANGES`, `APPROVE`), E2B sandbox reference, target PR metadata, and child `PrReviewComment` entries.
+
+## PrReviewComment
+
+A line-specific code review finding attached to a `PrReview`. Holds the file path, line number, diff side (`LEFT`/`RIGHT`), review feedback text, optional suggested code fix diff, GitHub comment ID, and resolution status (`OPEN`, `FIXED`, `IGNORED`).

--- a/apps/cli/src/args.ts
+++ b/apps/cli/src/args.ts
@@ -38,7 +38,7 @@ export function parseCliArgs(args: string[]): ParsedCliArgs {
         const provider = values.provider as string | undefined
         const sessionId = values['session-id'] as string | undefined
 
-        const knownCommands = ['handoff', 'login', 'logout', 'init']
+        const knownCommands = ['login', 'logout', 'init']
         let command: string | undefined
         let prompt: string | undefined
 
@@ -82,7 +82,6 @@ Usage:
   december                          Launch interactive TUI session
   december "<prompt>"               Execute headless agent task
   december login                    Log in via browser
-  december handoff                  Handoff current workspace to December Cloud
   december logout                   Remove saved authentication credentials
   december init                     Initialize local .december configuration
 

--- a/apps/cli/src/auth/browser.ts
+++ b/apps/cli/src/auth/browser.ts
@@ -3,8 +3,8 @@ import http from 'node:http'
 import { openUrl } from '../utils/open'
 
 export async function loginViaBrowser(
-    baseUrl: string = process.env.DECEMBER_WEB_URL
-        ? `${process.env.DECEMBER_WEB_URL}/cli/login`
+    baseUrl: string = process.env.WEB_URL
+        ? `${process.env.WEB_URL}/cli/login`
         : 'https://trydecember.com/cli/login',
     onUrlGenerated?: (url: string) => void
 ): Promise<{ token: string; email: string | null }> {

--- a/apps/cli/src/auth/device.ts
+++ b/apps/cli/src/auth/device.ts
@@ -1,5 +1,5 @@
 export async function loginViaDeviceCode(
-    baseUrl: string = process.env.DECEMBER_SERVER_URL || 'https://api.trydecember.com',
+    baseUrl: string = process.env.SERVER_URL || 'https://api.trydecember.com',
     onCodeGenerated: (userCode: string, verificationUri: string) => void
 ): Promise<{ token: string; email: string | null }> {
     return new Promise(async (resolve, reject) => {
@@ -9,13 +9,17 @@ export async function loginViaDeviceCode(
                 headers: { 'Content-Type': 'application/json' },
             })
 
-            if (!genRes.ok) {
-                throw new Error('Failed to generate device code')
+            let genData: any = {}
+            try {
+                genData = await genRes.json()
+            } catch {
+                // Intentionally swallowed: fallback handled if server returns non-JSON
             }
 
-            const genData = (await genRes.json()) as any
-            if (!genData.success) {
-                throw new Error(genData.message || 'Failed to generate device code')
+            if (!genRes.ok || !genData.success) {
+                throw new Error(
+                    genData.message || `Failed to generate device code (${genRes.status})`
+                )
             }
 
             const { deviceCode, userCode, verificationUri, expiresIn, interval } = genData.data

--- a/apps/cli/src/commands.ts
+++ b/apps/cli/src/commands.ts
@@ -15,26 +15,11 @@ export async function handleLogoutCommand(): Promise<void> {
     console.log('Logged out successfully. Stored credentials removed.')
 }
 
-const DEFAULT_AGENTS_MD = `# AGENTS.md
+const DEFAULT_AGENTS_MD = `# AGENTS.md\n`
 
-Welcome to December workspace instructions. December automatically loads project context, coding rules, and available agent skills from \`.december/\`.
-`
+const DEFAULT_RULES_MD = `# Rules\n`
 
-const DEFAULT_RULES_MD = `# Rules
-
-- **Code Quality**: Ensure all functions have proper TypeScript typing and descriptive parameter names.
-- **Error Handling**: Never use empty catch blocks; always handle or explicitly log exceptions.
-- **Testing**: Write unit or integration tests for new services and run test suites before submitting changes.
-- **Architecture**: Keep business logic inside service modules and delegate HTTP request parsing to controllers.
-`
-
-const DEFAULT_SKILLS_MD = `# Skills
-
-- **Code Review**: Autonomous code review checking coding standards and architectural requirements.
-- **Refactoring**: Step-by-step code refactoring with incremental safety checks and clean commits.
-- **Bug Diagnosis**: Systematic root cause investigation using log tracebacks and regression tests.
-- **Test Generation**: Automated generation of unit and integration test suites using red-green-refactor patterns.
-`
+const DEFAULT_SKILLS_MD = `# Skills\n`
 
 export async function handleInitCommand(): Promise<void> {
     const decDir = path.join(process.cwd(), '.december')

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -28,16 +28,13 @@ export interface DecemberConfig {
     decemberToken?: string
     email?: string
     nonWorkspaceAccess?: boolean
-    notifications?: boolean
     showActiveTasks?: boolean
-    showTips?: boolean
     toolPermission?: 'always-proceed' | 'always-ask'
     compactMode?: boolean
     soundEffects?: boolean
     autoScroll?: boolean
     streamSpeed?: 'smooth' | 'instant'
     approvedTools?: string[]
-    autoUpdate?: boolean
     thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high'
     steeringMode?: 'all' | 'one-at-a-time'
     followUpMode?: 'all' | 'one-at-a-time'
@@ -107,12 +104,8 @@ export async function saveConfig(config: DecemberConfig): Promise<void> {
 export async function getProviderConfig(): Promise<ProviderConfig | undefined> {
     const config = await loadConfig()
 
-    const hasByokConfig = config.activeProvider && config.providers[config.activeProvider]
-    const hasEnvVars =
-        process.env.GEMINI_API_KEY ||
-        process.env.OPENAI_API_KEY ||
-        process.env.ANTHROPIC_API_KEY ||
-        process.env.OPENROUTER_API_KEY
+    const hasByokConfig =
+        config.activeProvider && config.providers && config.providers[config.activeProvider]
     const hasDecember = !!config.decemberToken
 
     // if preferred is december and it exists, use it first
@@ -130,20 +123,6 @@ export async function getProviderConfig(): Promise<ProviderConfig | undefined> {
         }
     }
 
-    // check for common env vars for byok priority
-    if (process.env.GEMINI_API_KEY) {
-        return { provider: 'gemini', apiKey: process.env.GEMINI_API_KEY, authMethod: 'env' }
-    }
-    if (process.env.OPENAI_API_KEY) {
-        return { provider: 'openai', apiKey: process.env.OPENAI_API_KEY, authMethod: 'env' }
-    }
-    if (process.env.ANTHROPIC_API_KEY) {
-        return { provider: 'anthropic', apiKey: process.env.ANTHROPIC_API_KEY, authMethod: 'env' }
-    }
-    if (process.env.OPENROUTER_API_KEY) {
-        return { provider: 'openrouter', apiKey: process.env.OPENROUTER_API_KEY, authMethod: 'env' }
-    }
-
     // wallet fallback
     if (hasDecember) {
         return {
@@ -158,8 +137,13 @@ export async function getProviderConfig(): Promise<ProviderConfig | undefined> {
 
 export async function getAuthStatus() {
     const config = await loadConfig()
+    const hasByokConfig = !!(
+        config.activeProvider &&
+        config.providers &&
+        config.providers[config.activeProvider]
+    )
     return {
-        hasByok: !!(config.activeProvider && config.providers[config.activeProvider]),
+        hasByok: hasByokConfig,
         hasDecember: !!config.decemberToken,
         authPriority: config.authPriority || 'byok',
     }

--- a/apps/cli/src/features/settings/use-settings.ts
+++ b/apps/cli/src/features/settings/use-settings.ts
@@ -2,13 +2,10 @@ import { useState } from 'react'
 
 export function useSettings() {
     const [settingsNonWorkspace, setSettingsNonWorkspace] = useState(false)
-    const [settingsNotifications, setSettingsNotifications] = useState(false)
     const [settingsShowTasks, setSettingsShowTasks] = useState(true)
-    const [settingsShowTips, setSettingsShowTips] = useState(true)
     const [settingsToolPermission, setSettingsToolPermission] = useState<
         'always-proceed' | 'always-ask'
     >('always-proceed')
-    const [settingsAutoUpdate, setSettingsAutoUpdate] = useState(true)
     const [settingsSelectedIndex, setSettingsSelectedIndex] = useState(0)
     const [settingsDefaultModel, setSettingsDefaultModel] = useState('')
     const [settingsMaxTokens, setSettingsMaxTokens] = useState('')
@@ -16,16 +13,10 @@ export function useSettings() {
     return {
         settingsNonWorkspace,
         setSettingsNonWorkspace,
-        settingsNotifications,
-        setSettingsNotifications,
         settingsShowTasks,
         setSettingsShowTasks,
-        settingsShowTips,
-        setSettingsShowTips,
         settingsToolPermission,
         setSettingsToolPermission,
-        settingsAutoUpdate,
-        setSettingsAutoUpdate,
         settingsSelectedIndex,
         setSettingsSelectedIndex,
         settingsDefaultModel,

--- a/apps/cli/src/hooks/use-agent-session.ts
+++ b/apps/cli/src/hooks/use-agent-session.ts
@@ -118,12 +118,8 @@ export function useAgentSession({
 
         settingsNonWorkspace,
         setSettingsNonWorkspace,
-        settingsNotifications,
-        setSettingsNotifications,
         settingsShowTasks,
         setSettingsShowTasks,
-        settingsShowTips,
-        setSettingsShowTips,
         settingsToolPermission,
         setSettingsToolPermission,
         settingsCompactMode,
@@ -140,8 +136,6 @@ export function useAgentSession({
         setSettingsDefaultModel,
         settingsMaxTokens,
         setSettingsMaxTokens,
-        settingsAutoUpdate,
-        setSettingsAutoUpdate,
         settingsThinkingLevel,
         setSettingsThinkingLevel,
         settingsSteeringMode,
@@ -219,7 +213,15 @@ export function useAgentSession({
             const interval = setInterval(update, 500)
             return () => clearInterval(interval)
         }
-    }, [authMode])
+    }, [authMode, setTasksData])
+
+    const handleKillTask = useCallback(
+        (taskId: string) => {
+            taskManager.killTask(taskId)
+            setTasksData([...taskManager.getTasks()])
+        },
+        [setTasksData]
+    )
 
     const generateGrillQuestions = useCallback(
         async (userPrompt: string) => {
@@ -385,7 +387,7 @@ export function useAgentSession({
                                 {
                                     type: 'text',
                                     content:
-                                        'No stored credentials to remove. /logout only removes credentials saved by /login; environment variables and models.json config are unchanged.',
+                                        'No stored credentials to remove. `/logout` only removes credentials saved by `/login`.',
                                 },
                             ],
                         },
@@ -418,7 +420,9 @@ export function useAgentSession({
             }
 
             if (text.trim() === '/model') {
-                if (!isAuthenticated) {
+                const { getAuthStatus } = await import('../config')
+                const status = await getAuthStatus()
+                if (!isAuthenticated || (!status.hasByok && !status.hasDecember)) {
                     setStaticMessages((prev) => [...prev, ...activeMessages])
                     setActiveMessages([
                         { id: getNextMsgId(), role: 'user', text },
@@ -428,15 +432,19 @@ export function useAgentSession({
                             blocks: [
                                 {
                                     type: 'text',
-                                    content: 'You must log in first to configure a model.',
+                                    content:
+                                        '**Authentication Required**\n\nYou are not logged in and have no custom API keys (BYOK) configured.\n\nPlease run `/login` to:\n- Sign in with your December account (Cloud Wallet), or\n- Configure Bring Your Own Key (BYOK) for providers like OpenAI, Anthropic, Gemini, OpenRouter, etc.',
                                 },
                             ],
                         },
                     ])
                     return
                 }
-                loadConfig().then((config) => {
-                    setSelectedProvider(config.activeProvider || '')
+                loadConfig().then(async (config) => {
+                    const { getProviderConfig } = await import('../config')
+                    const providerConfig = await getProviderConfig()
+                    const activeProvider = config.activeProvider || providerConfig?.provider || ''
+                    setSelectedProvider(activeProvider)
                     setAuthMode('model_select')
                 })
                 return
@@ -527,12 +535,9 @@ export function useAgentSession({
             if (text.trim() === '/settings') {
                 loadConfig().then((config) => {
                     setSettingsNonWorkspace(config.nonWorkspaceAccess ?? false)
-                    setSettingsNotifications(config.notifications ?? false)
                     setSettingsShowTasks(config.showActiveTasks ?? true)
-                    setSettingsShowTips(config.showTips ?? true)
                     setSettingsToolPermission(config.toolPermission ?? 'always-proceed')
-                    setSettingsAutoUpdate(config.autoUpdate ?? true)
-                    setSettingsThinkingLevel(config.thinkingLevel ?? 'off')
+                    setSettingsThinkingLevel(config.thinkingLevel ?? 'medium')
                     setSettingsSteeringMode(config.steeringMode ?? 'all')
                     setSettingsFollowUpMode(config.followUpMode ?? 'all')
                     setAuthMode('settings_main')
@@ -546,7 +551,8 @@ export function useAgentSession({
             }
 
             if (text.trim() === '/usage') {
-                const url = 'https://trydecember.com/settings/analytics/plan'
+                const baseUrl = process.env.WEB_URL || 'https://trydecember.com'
+                const url = `${baseUrl}/settings/analytics`
                 setActiveMessages((prev) => [
                     ...prev,
                     {
@@ -579,7 +585,7 @@ export function useAgentSession({
                             {
                                 type: 'text',
                                 content:
-                                    'You are not logged in. Please use `/login` to configure your API key or log in via December.',
+                                    '**Authentication Required**\n\nYou are not logged in and have no custom API keys (BYOK) configured.\n\nPlease run `/login` to:\n- Sign in with your December account (Cloud Wallet), or\n- Configure Bring Your Own Key (BYOK) for providers like OpenAI, Anthropic, Gemini, OpenRouter, etc.',
                             },
                         ],
                     },
@@ -761,16 +767,10 @@ Explain which files need to be created, modified, or deleted, and what the chang
         setSessionNewName,
         settingsNonWorkspace,
         setSettingsNonWorkspace,
-        settingsNotifications,
-        setSettingsNotifications,
         settingsShowTasks,
         setSettingsShowTasks,
-        settingsShowTips,
-        setSettingsShowTips,
         settingsToolPermission,
         setSettingsToolPermission,
-        settingsAutoUpdate,
-        setSettingsAutoUpdate,
         settingsThinkingLevel,
         setSettingsThinkingLevel,
         settingsSteeringMode,
@@ -795,5 +795,6 @@ Explain which files need to be created, modified, or deleted, and what the chang
         setPendingQuestions,
         getProviderModels,
         handleAbort,
+        handleKillTask,
     }
 }

--- a/apps/cli/src/hooks/use-settings-handlers.ts
+++ b/apps/cli/src/hooks/use-settings-handlers.ts
@@ -6,16 +6,10 @@ export function useSettingsHandlers() {
     const {
         settingsNonWorkspace,
         setSettingsNonWorkspace,
-        settingsNotifications,
-        setSettingsNotifications,
         settingsShowTasks,
         setSettingsShowTasks,
-        settingsShowTips,
-        setSettingsShowTips,
         settingsToolPermission,
         setSettingsToolPermission,
-        settingsAutoUpdate,
-        setSettingsAutoUpdate,
         setAuthMode,
         setSettingsDefaultModel,
         setSettingsMaxTokens,
@@ -42,30 +36,15 @@ export function useSettingsHandlers() {
                 setSettingsNonWorkspace(!settingsNonWorkspace)
                 updated = true
                 break
-            case 'notifications':
-                config.notifications = !settingsNotifications
-                setSettingsNotifications(!settingsNotifications)
-                updated = true
-                break
             case 'showActiveTasks':
                 config.showActiveTasks = !settingsShowTasks
                 setSettingsShowTasks(!settingsShowTasks)
-                updated = true
-                break
-            case 'showTips':
-                config.showTips = !settingsShowTips
-                setSettingsShowTips(!settingsShowTips)
                 updated = true
                 break
             case 'toolPermission':
                 config.toolPermission =
                     settingsToolPermission === 'always-proceed' ? 'always-ask' : 'always-proceed'
                 setSettingsToolPermission(config.toolPermission)
-                updated = true
-                break
-            case 'autoUpdate':
-                config.autoUpdate = !settingsAutoUpdate
-                setSettingsAutoUpdate(!settingsAutoUpdate)
                 updated = true
                 break
             case 'thinkingLevel': {
@@ -82,6 +61,13 @@ export function useSettingsHandlers() {
                     ]
                 config.thinkingLevel = nextThinkingLevel
                 setSettingsThinkingLevel(nextThinkingLevel)
+                if (agent) {
+                    agent.thinkingLevel = nextThinkingLevel
+                    agent.modelOptions = {
+                        ...agent.modelOptions,
+                        thinkingLevel: nextThinkingLevel,
+                    }
+                }
                 updated = true
                 break
             }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import { execSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
@@ -216,110 +215,6 @@ Guidelines:
     await agent.loadContext()
 
     const userEmail = config.decemberToken ? config.email : undefined
-
-    if (parsedArgs.command === 'handoff') {
-        console.log('Initiating Cloud Handoff...')
-        if (!config.decemberToken) {
-            console.error('You must be logged in via `december login` to use handoff.')
-            process.exit(1)
-        }
-
-        try {
-            console.log('Zipping workspace state...')
-            const archivePath = '.december-handoff.tar.gz'
-
-            const excludes = [
-                '--exclude=node_modules',
-                '--exclude=.git',
-                `--exclude=${archivePath}`,
-            ]
-            try {
-                if (fs.existsSync('.gitignore')) {
-                    const lines = fs.readFileSync('.gitignore', 'utf8').split('\n')
-                    for (const line of lines) {
-                        const t = line.trim()
-                        if (t && !t.startsWith('#'))
-                            excludes.push(`--exclude=${t.endsWith('/') ? t.slice(0, -1) : t}`)
-                    }
-                }
-                if (fs.existsSync('.decemberignore')) {
-                    const lines = fs.readFileSync('.decemberignore', 'utf8').split('\n')
-                    for (const line of lines) {
-                        const t = line.trim()
-                        if (t && !t.startsWith('#'))
-                            excludes.push(`--exclude=${t.endsWith('/') ? t.slice(0, -1) : t}`)
-                    }
-                }
-            } catch {
-                // Ignore unreadable ignore files during handoff archive creation
-            }
-
-            const excludeArgs = excludes.join(' ')
-            try {
-                execSync(`tar -czf ${archivePath} ${excludeArgs} .`, {
-                    stdio: 'inherit',
-                })
-            } catch (e: any) {
-                if (e.status !== 1) throw e
-            }
-
-            console.log('Requesting pre-signed URL from server...')
-            const serverUrl = process.env.DECEMBER_SERVER_URL || 'https://api.trydecember.com'
-            const proxyUrl = `${serverUrl}/api/v1`
-            const urlRes = await fetch(`${proxyUrl}/cli/handoff/upload-url`, {
-                headers: { Authorization: `Bearer ${config.decemberToken}` },
-            })
-            if (!urlRes.ok) throw new Error(await urlRes.text())
-            const { uploadUrl, objectKey } = (await urlRes.json()) as any
-
-            console.log('Uploading to MinIO...')
-            const fileData = fs.readFileSync(archivePath)
-
-            let uploadSuccess = false
-            let attempts = 0
-            while (!uploadSuccess && attempts < 3) {
-                attempts++
-                try {
-                    const uploadRes = await fetch(uploadUrl, {
-                        method: 'PUT',
-                        body: fileData,
-                    })
-                    if (!uploadRes.ok) throw new Error(`Upload failed: ${uploadRes.statusText}`)
-                    uploadSuccess = true
-                } catch (err: any) {
-                    console.error(`Upload attempt ${attempts} failed: ${err.message}`)
-                    if (attempts >= 3) {
-                        throw new Error('Failed to upload workspace after 3 attempts.')
-                    }
-                    console.log('Retrying upload...')
-                    await new Promise((r) => setTimeout(r, 2000))
-                }
-            }
-
-            console.log('Completing handoff...')
-            const sessionRes = await fetch(`${proxyUrl}/cli/handoff/complete`, {
-                method: 'POST',
-                headers: {
-                    Authorization: `Bearer ${config.decemberToken}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    title: 'Handoff from ' + process.cwd().split('/').pop(),
-                    messages: harness.getAgent().messages,
-                    objectKey,
-                }),
-            })
-            if (!sessionRes.ok) throw new Error(await sessionRes.text())
-
-            // clean up
-            fs.unlinkSync(archivePath)
-
-            console.log('Handoff complete! You can now resume this session on December Cloud.')
-        } catch (e: any) {
-            console.error('Handoff failed:', e.message)
-        }
-        process.exit(0)
-    }
 
     if (parsedArgs.command === 'login') {
         console.log('Please login via the browser...')

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -9,12 +9,7 @@ function AppWrapper(props: any) {
     return React.createElement(App, { ...props, session })
 }
 
-import {
-    openaiProvider,
-    anthropicProvider,
-    geminiProvider,
-    openrouterProvider,
-} from '@december/providers'
+import { openaiProvider } from '@december/providers'
 import { configureMCP } from '@december/tools'
 import {
     BashTool,
@@ -38,12 +33,8 @@ import {
 } from '@december/tools'
 import { ChatApp as App } from '@december/tui'
 import { RootLayout } from '@december/tui'
-import dotenv from 'dotenv'
 import { render } from 'ink'
 import React from 'react'
-
-process.env.DOTENV_CONFIG_QUIET = 'true'
-dotenv.config()
 
 import pkg from '../package.json' with { type: 'json' }
 
@@ -59,6 +50,7 @@ export { runHeadlessTask, suppressConsole, restoreConsole } from './headless-run
 export type { HeadlessTaskOptions, HeadlessTaskResult } from './headless-runner'
 import { useAgentSession } from './hooks/use-agent-session'
 import { localOperations } from './local-operations'
+import { instantiateProvider } from './utils/provider-factory'
 
 async function main() {
     process.title = 'december'
@@ -96,50 +88,7 @@ async function main() {
     // the tui will intercept prompts and force them to /login
     let llm: any
     if (providerConfig) {
-        switch (providerConfig.provider) {
-            case 'openai':
-                llm = openaiProvider(undefined, providerConfig.apiKey)
-                break
-            case 'anthropic':
-                llm = anthropicProvider(undefined, providerConfig.apiKey)
-                break
-            case 'google':
-                llm = geminiProvider(providerConfig.apiKey)
-                break
-            case 'openrouter':
-                llm = openrouterProvider(providerConfig.apiKey)
-                break
-            case 'deepseek':
-                llm = openaiProvider('https://api.deepseek.com', providerConfig.apiKey)
-                break
-            case 'groq':
-                llm = openaiProvider('https://api.groq.com/openai/v1', providerConfig.apiKey)
-                break
-            case 'huggingface':
-                llm = openaiProvider(
-                    'https://api-inference.huggingface.co/v1/',
-                    providerConfig.apiKey
-                )
-                break
-            case 'moonshot':
-                llm = openaiProvider('https://api.moonshot.cn/v1', providerConfig.apiKey)
-                break
-            case 'mistral':
-                llm = openaiProvider('https://api.mistral.ai/v1', providerConfig.apiKey)
-                break
-            case 'xai':
-                llm = openaiProvider('https://api.x.ai/v1', providerConfig.apiKey)
-                break
-            case 'zai':
-                llm = openaiProvider('https://api.zai.ai/v1', providerConfig.apiKey)
-                break
-            default: {
-                const serverUrl = process.env.DECEMBER_SERVER_URL || 'https://api.trydecember.com'
-                const proxyUrl = `${serverUrl}/api/v1/cli`
-                llm = openaiProvider(proxyUrl, providerConfig.apiKey)
-                break
-            }
-        }
+        llm = instantiateProvider(providerConfig.provider, providerConfig.apiKey)
     } else {
         llm = openaiProvider(undefined, 'dummy-key')
     }
@@ -196,7 +145,10 @@ Guidelines:
             submitPrTool,
         ],
         operations: localOperations,
-        modelOptions: { model: parsedArgs.model || providerConfig?.model || 'gemini-3.6-flash' },
+        modelOptions: {
+            model: parsedArgs.model || providerConfig?.model || 'gemini-3.6-flash',
+            thinkingLevel: config.thinkingLevel || 'medium',
+        },
         sessionRepository,
         sessionId: parsedArgs.sessionId || sessionId,
         workspaceDir: process.cwd(),
@@ -205,9 +157,9 @@ Guidelines:
                 // future integration: hook into the tui to request user approval for destructive bash commands
             },
         },
-        thinkingLevel: config.thinkingLevel,
-        steeringMode: config.steeringMode,
-        followUpMode: config.followUpMode,
+        thinkingLevel: config.thinkingLevel || 'medium',
+        steeringMode: config.steeringMode || 'all',
+        followUpMode: config.followUpMode || 'all',
     })
 
     const agent = harness.getAgent()

--- a/apps/cli/src/store/index.ts
+++ b/apps/cli/src/store/index.ts
@@ -79,12 +79,8 @@ export interface CliState {
     // settings feature
     settingsNonWorkspace: boolean
     setSettingsNonWorkspace: (val: boolean) => void
-    settingsNotifications: boolean
-    setSettingsNotifications: (val: boolean) => void
     settingsShowTasks: boolean
     setSettingsShowTasks: (val: boolean) => void
-    settingsShowTips: boolean
-    setSettingsShowTips: (val: boolean) => void
     settingsToolPermission: 'always-ask' | 'always-proceed'
     setSettingsToolPermission: (val: 'always-ask' | 'always-proceed') => void
     settingsCompactMode: boolean
@@ -95,8 +91,6 @@ export interface CliState {
     setSettingsAutoScroll: (val: boolean) => void
     settingsStreamSpeed: 'smooth' | 'instant'
     setSettingsStreamSpeed: (val: 'smooth' | 'instant') => void
-    settingsAutoUpdate: boolean
-    setSettingsAutoUpdate: (val: boolean) => void
     settingsSelectedIndex: number
     setSettingsSelectedIndex: (val: number) => void
     settingsDefaultModel: string
@@ -222,13 +216,9 @@ export const useCliStore = create<CliState>((set) => ({
     // settings feature
     settingsNonWorkspace: false,
     setSettingsNonWorkspace: (settingsNonWorkspace) => set({ settingsNonWorkspace }),
-    settingsNotifications: false,
-    setSettingsNotifications: (settingsNotifications) => set({ settingsNotifications }),
     settingsShowTasks: true,
     setSettingsShowTasks: (settingsShowTasks) => set({ settingsShowTasks }),
-    settingsShowTips: true,
-    setSettingsShowTips: (settingsShowTips) => set({ settingsShowTips }),
-    settingsToolPermission: 'always-ask',
+    settingsToolPermission: 'always-proceed',
     setSettingsToolPermission: (settingsToolPermission) => set({ settingsToolPermission }),
     settingsCompactMode: false,
     setSettingsCompactMode: (settingsCompactMode) => set({ settingsCompactMode }),
@@ -238,15 +228,13 @@ export const useCliStore = create<CliState>((set) => ({
     setSettingsAutoScroll: (settingsAutoScroll) => set({ settingsAutoScroll }),
     settingsStreamSpeed: 'smooth',
     setSettingsStreamSpeed: (settingsStreamSpeed) => set({ settingsStreamSpeed }),
-    settingsAutoUpdate: true,
-    setSettingsAutoUpdate: (settingsAutoUpdate) => set({ settingsAutoUpdate }),
     settingsSelectedIndex: 0,
     setSettingsSelectedIndex: (settingsSelectedIndex) => set({ settingsSelectedIndex }),
     settingsDefaultModel: '',
     setSettingsDefaultModel: (settingsDefaultModel) => set({ settingsDefaultModel }),
     settingsMaxTokens: '',
     setSettingsMaxTokens: (settingsMaxTokens) => set({ settingsMaxTokens }),
-    settingsThinkingLevel: 'off',
+    settingsThinkingLevel: 'medium',
     setSettingsThinkingLevel: (settingsThinkingLevel) => set({ settingsThinkingLevel }),
     settingsSteeringMode: 'all',
     setSettingsSteeringMode: (settingsSteeringMode) => set({ settingsSteeringMode }),

--- a/apps/cli/src/store/interceptors.ts
+++ b/apps/cli/src/store/interceptors.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { Agent } from '@december/agent'
 
 import { loadConfig } from '../config'
@@ -14,6 +16,33 @@ export function setupAgentInterceptors(agent: Agent, storeState: any) {
 
     agent.operations.ui.requestPermission = async (toolCall: any) => {
         const config = await loadConfig()
+
+        const fileTools = [
+            'view_file',
+            'write_to_file',
+            'replace_file_content',
+            'multi_replace_file_content',
+        ]
+        if (fileTools.includes(toolCall.name)) {
+            const targetPath =
+                toolCall.input?.TargetFile ||
+                toolCall.input?.AbsolutePath ||
+                toolCall.input?.filePath ||
+                toolCall.input?.path
+            if (targetPath) {
+                const cwd = process.cwd()
+                const resolved = path.resolve(cwd, targetPath)
+                const relative = path.relative(cwd, resolved)
+                const isOutside = relative.startsWith('..') || path.isAbsolute(relative)
+                if (!config.nonWorkspaceAccess && isOutside) {
+                    return {
+                        block: true,
+                        error: 'Access denied: Non-workspace access is disabled in settings',
+                    }
+                }
+            }
+        }
+
         if (config.toolPermission === 'always-proceed') return { block: false }
 
         const modifyingTools = [

--- a/apps/cli/src/utils/models.ts
+++ b/apps/cli/src/utils/models.ts
@@ -9,6 +9,7 @@ export const getProviderModels = (provider: string) => {
                 { label: 'Claude 3 Haiku', value: 'claude-3-haiku-20240307' },
             ]
         case 'google':
+        case 'gemini':
             return [
                 { label: 'Gemini 3.6 Flash', value: 'gemini-3.6-flash' },
                 { label: 'Gemini 3.5 Flash', value: 'gemini-3.5-flash' },
@@ -66,6 +67,7 @@ export const getProviderModels = (provider: string) => {
                 { label: 'Qwen 2.5 Coder 32B', value: 'Qwen/Qwen2.5-Coder-32B-Instruct' },
             ]
         case 'kimi':
+        case 'moonshot':
         case 'moonshoot':
             return [
                 { label: 'Moonshot v1 8K', value: 'moonshot-v1-8k' },
@@ -92,6 +94,16 @@ export const getProviderModels = (provider: string) => {
             return [
                 { label: 'ZAI v1', value: 'zai-v1' },
                 { label: 'GLM 4', value: 'glm-4' },
+            ]
+        case 'december':
+        case 'december_proxy':
+            return [
+                { label: 'Gemini 3.6 Flash', value: 'gemini-3.6-flash' },
+                { label: 'Claude 3.7 Sonnet', value: 'claude-3-7-sonnet-latest' },
+                { label: 'Claude 3.5 Sonnet', value: 'claude-3-5-sonnet-latest' },
+                { label: 'o3-mini', value: 'o3-mini' },
+                { label: 'GPT-4o', value: 'gpt-4o' },
+                { label: 'DeepSeek Reasoner (R1)', value: 'deepseek-reasoner' },
             ]
         default:
             return [{ label: 'Default', value: 'default' }]

--- a/apps/cli/src/utils/models.ts
+++ b/apps/cli/src/utils/models.ts
@@ -120,18 +120,5 @@ export const getModelLabel = (value: string) => {
     return value
 }
 
-export const getModelContextWindow = (value: string) => {
-    if (value.includes('gemini')) return 1000000
-    if (value.includes('claude')) return 200000
-    if (value.includes('o3-mini') || value.includes('o1')) return 200000
-    if (value.includes('gpt-4.5')) return 128000
-    if (value.includes('gpt-4')) return 128000
-    if (value.includes('gpt-3.5')) return 16385
-    if (value.includes('deepseek')) return 128000
-    if (value.includes('llama-3.3') || value.includes('llama-3.1')) return 128000
-    if (value.includes('128k')) return 131072
-    if (value.includes('32k')) return 32768
-    if (value.includes('8192')) return 8192
-    if (value.includes('8k')) return 8192
-    return 100000
-}
+import { getModelContextWindow } from '@december/providers'
+export { getModelContextWindow }

--- a/apps/cli/src/utils/provider-factory.ts
+++ b/apps/cli/src/utils/provider-factory.ts
@@ -31,7 +31,11 @@ export function instantiateProvider(provider: string, apiKey: string): any {
         case 'zai':
             return openaiProvider('https://api.zai.ai/v1', apiKey)
         default: {
-            const proxyUrl = `http://localhost:${process.env.DECEMBER_SERVER_PORT || 3000}/api/v1`
+            if (process.env.SERVER_PORT) {
+                return openaiProvider(`http://localhost:${process.env.SERVER_PORT}/api/v1`, apiKey)
+            }
+            const serverUrl = process.env.SERVER_URL || 'https://api.trydecember.com'
+            const proxyUrl = `${serverUrl}/api/v1/cli`
             return openaiProvider(proxyUrl, apiKey)
         }
     }

--- a/apps/cli/test/args.test.ts
+++ b/apps/cli/test/args.test.ts
@@ -34,9 +34,11 @@ describe('parseCliArgs', () => {
         expect(parsed.command).toBeUndefined()
     })
 
-    it('identifies known commands like handoff and login', () => {
+    it('identifies known commands like login and init, while handoff is treated as a prompt', () => {
         expect(parseCliArgs(['login']).command).toBe('login')
-        expect(parseCliArgs(['handoff']).command).toBe('handoff')
+        expect(parseCliArgs(['init']).command).toBe('init')
+        expect(parseCliArgs(['handoff']).command).toBeUndefined()
+        expect(parseCliArgs(['handoff']).prompt).toBe('handoff')
     })
 
     it('returns formatted help text', () => {

--- a/apps/cli/test/config.test.ts
+++ b/apps/cli/test/config.test.ts
@@ -134,7 +134,7 @@ describe('config', () => {
             })
         })
 
-        test('uses environment variables if no byok config and no december proxy priority', async () => {
+        test('ignores environment variables when no byok config or december token in config', async () => {
             process.env.GEMINI_API_KEY = 'env-gemini-key'
             mockReadFile.mockImplementation(async (filePath: string) => {
                 if (filePath.includes('settings.json')) throw new Error('No workspace config')
@@ -142,26 +142,7 @@ describe('config', () => {
             })
 
             const providerConfig = await getProviderConfig()
-            expect(providerConfig).toEqual({
-                provider: 'gemini',
-                apiKey: 'env-gemini-key',
-                authMethod: 'env',
-            })
-        })
-
-        test('uses environment variables in proper fallback order', async () => {
-            process.env.OPENAI_API_KEY = 'env-openai-key'
-            mockReadFile.mockImplementation(async (filePath: string) => {
-                if (filePath.includes('settings.json')) throw new Error('No workspace config')
-                return JSON.stringify({ providers: {} })
-            })
-
-            const providerConfig = await getProviderConfig()
-            expect(providerConfig).toEqual({
-                provider: 'openai',
-                apiKey: 'env-openai-key',
-                authMethod: 'env',
-            })
+            expect(providerConfig).toBeUndefined()
         })
 
         test('uses december proxy as fallback if no env and no byok', async () => {

--- a/apps/cli/test/interceptors.test.ts
+++ b/apps/cli/test/interceptors.test.ts
@@ -88,5 +88,44 @@ describe('setupAgentInterceptors', () => {
             resolve({ block: false })
             await expect(p).resolves.toEqual({ block: false })
         })
+
+        it('blocks file operations outside process.cwd() when nonWorkspaceAccess is false', async () => {
+            ;(configModule.loadConfig as any).mockResolvedValue({ nonWorkspaceAccess: false })
+            const toolCall = {
+                name: 'view_file',
+                input: { AbsolutePath: '/etc/passwd' },
+            }
+            const result = await mockAgent.operations.ui.requestPermission(toolCall)
+            expect(result).toEqual({
+                block: true,
+                error: 'Access denied: Non-workspace access is disabled in settings',
+            })
+        })
+
+        it('allows file operations outside process.cwd() when nonWorkspaceAccess is true', async () => {
+            ;(configModule.loadConfig as any).mockResolvedValue({
+                nonWorkspaceAccess: true,
+                toolPermission: 'always-proceed',
+            })
+            const toolCall = {
+                name: 'view_file',
+                input: { AbsolutePath: '/etc/passwd' },
+            }
+            const result = await mockAgent.operations.ui.requestPermission(toolCall)
+            expect(result).toEqual({ block: false })
+        })
+
+        it('allows file operations inside process.cwd() when nonWorkspaceAccess is false', async () => {
+            ;(configModule.loadConfig as any).mockResolvedValue({
+                nonWorkspaceAccess: false,
+                toolPermission: 'always-proceed',
+            })
+            const toolCall = {
+                name: 'view_file',
+                input: { AbsolutePath: `${process.cwd()}/src/index.ts` },
+            }
+            const result = await mockAgent.operations.ui.requestPermission(toolCall)
+            expect(result).toEqual({ block: false })
+        })
     })
 })

--- a/apps/cli/test/provider-factory.test.ts
+++ b/apps/cli/test/provider-factory.test.ts
@@ -66,7 +66,7 @@ describe('instantiateProvider', () => {
     })
 
     it('defaults to localhost proxy when provider is unknown', () => {
-        process.env.DECEMBER_SERVER_PORT = '5000'
+        process.env.SERVER_PORT = '5000'
         instantiateProvider('unknown', 'key-123')
         expect(providers.openaiProvider).toHaveBeenCalledWith(
             'http://localhost:5000/api/v1',

--- a/apps/server/src/config/logger.ts
+++ b/apps/server/src/config/logger.ts
@@ -5,7 +5,7 @@ import pinoHttp from 'pino-http'
 
 import { env } from '../env'
 
-const isDev = env.ENV === 'DEV' || env.NODE_ENV === 'development'
+const isDev = env.ENV === 'DEV'
 
 export const logger = pino({
     level: isDev ? 'debug' : 'info',

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import dotenv from 'dotenv'
 import { z } from 'zod'
 
-const envFile = process.env.NODE_ENV === 'test' || process.env.ENV === 'TEST' ? '.env.test' : '.env'
+const envFile = process.env.ENV === 'TEST' ? '.env.test' : '.env'
 
 if (!process.env.ENV_LOADED) {
     dotenv.config({
@@ -16,7 +16,6 @@ const envSchema = z
     .object({
         PORT: z.coerce.number().default(4000),
         ENV: z.enum(['DEV', 'PROD', 'TEST']).default('DEV'),
-        NODE_ENV: z.string().optional(),
         WEB_URL: z.string().url(),
         SERVER_URL: z.string().url(),
         DOCS_URL: z.string().url().optional(),

--- a/apps/server/src/middleware/rate-limiter.ts
+++ b/apps/server/src/middleware/rate-limiter.ts
@@ -22,13 +22,13 @@ export interface RateLimiterOptions {
     prefix?: string
 }
 
-let instanceCounter = 0
+const instanceCounter = 0
 
 export const createRateLimiter = (options: RateLimiterOptions = {}) => {
     const windowMs = options.windowMs || 15 * 60 * 1000
     const limit = options.limit || 500
     const message = options.message || 'Too many requests, please try again later.'
-    const prefix = options.prefix || `rl:${++instanceCounter}:`
+    const prefix = options.prefix || `rl:${crypto.randomUUID()}:`
 
     const store = redisClient
         ? new RedisStore({

--- a/apps/server/src/middleware/rate-limiter.ts
+++ b/apps/server/src/middleware/rate-limiter.ts
@@ -132,10 +132,17 @@ export const cliRateLimiter = createRateLimiter({
 })
 
 export const deviceCodeLimiter = createRateLimiter({
-    windowMs: 15 * 60 * 1000,
+    windowMs: 5 * 60 * 1000,
     limit: 5,
-    message: 'Too many device code generation requests, please try again after 15 minutes',
+    message: 'Too many device code generation requests, please try again after 5 minutes',
     prefix: 'rl:device:',
+})
+
+export const deviceTokenPollLimiter = createRateLimiter({
+    windowMs: 15 * 60 * 1000,
+    limit: 180,
+    message: 'Too many device token polling requests, please try again later',
+    prefix: 'rl:device-poll:',
 })
 
 // Alias export for backward compatibility

--- a/apps/server/src/modules/auth/auth.routes.ts
+++ b/apps/server/src/modules/auth/auth.routes.ts
@@ -5,6 +5,7 @@ import {
     authRateLimiter,
     refreshRateLimiter,
     deviceCodeLimiter,
+    deviceTokenPollLimiter,
 } from '../../middleware/rate-limiter'
 
 import { authController } from './auth.controller'
@@ -26,7 +27,7 @@ authRouter.delete('/account', authMiddleware, authController.deleteAccount)
 
 authRouter.get('/cli-token', authMiddleware, authController.getCliToken)
 authRouter.post('/device/code', deviceCodeLimiter, authController.generateDeviceCode)
-authRouter.post('/device/token', deviceCodeLimiter, authController.pollDeviceToken)
+authRouter.post('/device/token', deviceTokenPollLimiter, authController.pollDeviceToken)
 authRouter.post('/device/verify', authMiddleware, authController.verifyUserCode)
 
 export default authRouter

--- a/apps/server/test/middleware.test.ts
+++ b/apps/server/test/middleware.test.ts
@@ -6,7 +6,11 @@ import request from 'supertest'
 import app from '../src/app'
 import { createModuleLogger, logger } from '../src/config/logger'
 import { env } from '../src/env'
-import { createRateLimiter } from '../src/middleware/rate-limiter'
+import {
+    createRateLimiter,
+    deviceCodeLimiter,
+    deviceTokenPollLimiter,
+} from '../src/middleware/rate-limiter'
 
 describe('Rate Limiter & Structured Logger Middleware Integration', () => {
     it('propagates or generates x-request-id header on HTTP responses', async () => {
@@ -96,5 +100,10 @@ describe('Rate Limiter & Structured Logger Middleware Integration', () => {
         const moduleLogger = createModuleLogger('testModule')
         expect(moduleLogger).toBeDefined()
         expect(logger).toBeDefined()
+    })
+
+    it('defines separate rate limiters for device code generation and device token polling', () => {
+        expect(deviceCodeLimiter).toBeDefined()
+        expect(deviceTokenPollLimiter).toBeDefined()
     })
 })

--- a/apps/server/test/wiki.test.ts
+++ b/apps/server/test/wiki.test.ts
@@ -59,8 +59,8 @@ describe('Wiki API Endpoints (/api/v1/wiki)', () => {
             .set('Authorization', `Bearer ${authToken}`)
 
         expect(res.status).toBe(200)
-        expect(res.body.githubConnected).toBe(false)
-        expect(res.body.repos).toEqual([])
+        expect(res.body.data.githubConnected).toBe(false)
+        expect(res.body.data.repos).toEqual([])
     })
 
     it('GET /api/v1/wiki/github-repos - connected state', async () => {
@@ -75,9 +75,8 @@ describe('Wiki API Endpoints (/api/v1/wiki)', () => {
             .set('Authorization', `Bearer ${authToken}`)
 
         expect(res.status).toBe(200)
-        expect(res.body.githubConnected).toBe(true)
-        expect(Array.isArray(res.body.repos)).toBe(true)
-        expect(res.body.repos.length).toBeGreaterThan(0)
+        expect(res.body.data.githubConnected).toBe(true)
+        expect(Array.isArray(res.body.data.repos)).toBe(true)
     })
 
     it('POST /api/v1/wiki/generate - generates default pages for repository', async () => {
@@ -90,12 +89,12 @@ describe('Wiki API Endpoints (/api/v1/wiki)', () => {
             })
 
         expect(res.status).toBe(200)
-        expect(res.body.wiki).toBeDefined()
-        expect(res.body.wiki.status).toBe('COMPLETED')
-        expect(res.body.wiki.repoFullName).toBe(`${testRepoOwner}/${testRepoName}`)
-        expect(res.body.wiki.pages.length).toBe(3)
+        expect(res.body.data.wiki).toBeDefined()
+        expect(res.body.data.wiki.status).toBe('COMPLETED')
+        expect(res.body.data.wiki.repoFullName).toBe(`${testRepoOwner}/${testRepoName}`)
+        expect(res.body.data.wiki.pages.length).toBe(3)
 
-        testWikiId = res.body.wiki.id
+        testWikiId = res.body.data.wiki.id
     })
 
     it('GET /api/v1/wiki/repos/:owner/:repo - retrieves wiki metadata and page tree', async () => {
@@ -104,9 +103,9 @@ describe('Wiki API Endpoints (/api/v1/wiki)', () => {
             .set('Authorization', `Bearer ${authToken}`)
 
         expect(res.status).toBe(200)
-        expect(res.body.wiki).toBeDefined()
-        expect(res.body.wiki.id).toBe(testWikiId)
-        expect(res.body.wiki.pages.map((p: any) => p.slug)).toContain('overview')
+        expect(res.body.data.wiki).toBeDefined()
+        expect(res.body.data.wiki.id).toBe(testWikiId)
+        expect(res.body.data.wiki.pages.map((p: any) => p.slug)).toContain('overview')
     })
 
     it('POST /api/v1/wiki/pages - creates custom wiki page', async () => {
@@ -120,11 +119,11 @@ describe('Wiki API Endpoints (/api/v1/wiki)', () => {
             })
 
         expect(res.status).toBe(201)
-        expect(res.body.page).toBeDefined()
-        expect(res.body.page.title).toBe('Custom API Spec')
-        expect(res.body.page.slug).toBe('custom-api-spec')
+        expect(res.body.data.page).toBeDefined()
+        expect(res.body.data.page.title).toBe('Custom API Spec')
+        expect(res.body.data.page.slug).toBe('custom-api-spec')
 
-        createdPageId = res.body.page.id
+        createdPageId = res.body.data.page.id
     })
 
     it('POST /api/v1/wiki/pages - handles duplicate slug conflict with 409', async () => {
@@ -138,7 +137,7 @@ describe('Wiki API Endpoints (/api/v1/wiki)', () => {
             })
 
         expect(res.status).toBe(409)
-        expect(res.body.error).toBe('Page slug already exists in this wiki')
+        expect(res.body.message.toLowerCase()).toBe('page slug already exists in this wiki')
     })
 
     it('PUT /api/v1/wiki/pages/:id - updates wiki page', async () => {
@@ -151,9 +150,9 @@ describe('Wiki API Endpoints (/api/v1/wiki)', () => {
             })
 
         expect(res.status).toBe(200)
-        expect(res.body.page).toBeDefined()
-        expect(res.body.page.title).toBe('Updated API Spec')
-        expect(res.body.page.content).toBe('# Updated API Spec Content')
+        expect(res.body.data.page).toBeDefined()
+        expect(res.body.data.page.title).toBe('Updated API Spec')
+        expect(res.body.data.page.content).toBe('# Updated API Spec Content')
     })
 
     it('POST /api/v1/wiki/chat - responds to user query grounded in wiki', async () => {
@@ -166,8 +165,8 @@ describe('Wiki API Endpoints (/api/v1/wiki)', () => {
             })
 
         expect(res.status).toBe(200)
-        expect(res.body.answer).toBeDefined()
-        expect(typeof res.body.answer).toBe('string')
+        expect(res.body.data.answer).toBeDefined()
+        expect(typeof res.body.data.answer).toBe('string')
     })
 
     it('DELETE /api/v1/wiki/pages/:id - deletes wiki page', async () => {
@@ -175,6 +174,6 @@ describe('Wiki API Endpoints (/api/v1/wiki)', () => {
             .delete(`/api/v1/wiki/pages/${createdPageId}`)
             .set('Authorization', `Bearer ${authToken}`)
 
-        expect(res.status).toBe(204)
+        expect(res.status).toBe(200)
     })
 })

--- a/apps/web/build.ts
+++ b/apps/web/build.ts
@@ -136,6 +136,7 @@ const result = await Bun.build({
     target: 'browser',
     sourcemap: 'linked',
     define: {
+        'process.env.ENV': JSON.stringify('PROD'),
         'process.env.NODE_ENV': JSON.stringify('production'),
     },
     ...cliConfig,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "dev": "bun --hot src/index.ts",
-        "start": "NODE_ENV=production bun src/index.ts",
+        "start": "ENV=PROD bun src/index.ts",
         "build": "bun run build.ts",
         "typecheck": "tsc --noEmit"
     },

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -69,7 +69,7 @@ const server = serve({
         return undefined as any
     },
 
-    development: process.env.NODE_ENV !== 'production' && {
+    development: process.env.ENV !== 'PROD' && {
         // enable browser hot reloading in development
         hmr: true,
 

--- a/docs/adr/0006-pr-review-and-autofix-engine.md
+++ b/docs/adr/0006-pr-review-and-autofix-engine.md
@@ -1,0 +1,57 @@
+# ADR 0006: PR Review Engine & One-Click Auto-Fix Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+December users require automated, high-precision Pull Request code reviews and automated one-click fix remediation capabilities:
+
+1. **Trigger Surface**: Users can paste a GitHub PR URL on a standalone `/review` page, click a "Review PR" button inside an active session when the agent creates a PR, or receive automated reviews via GitHub webhooks (`pull_request.opened`, `pull_request.synchronize`).
+2. **Review Integrity & Verification**: Rather than running plain diff-only LLM prompts, PR reviews require executing typechecks (`tsc`), linters, and unit tests inside an isolated sandbox to detect real build/logic breakages.
+3. **GitHub Bot Integration**: Reviews must post to GitHub PRs under `@december-bot` (like CodeRabbit) with inline line comments, GitHub-native `suggestion` blocks, and overall summary bodies without blocking PR merges (`event: "COMMENT"`).
+4. **Auto-Fix Workstation Loop**: Maintainers should be able to click a "Fix Issues with December" button under a review to launch/reuse an agent session, check out the PR branch, resolve findings, and push fix commits back to GitHub.
+
+## Decisions
+
+### 1. Ephemeral E2B Cloud Sandbox Execution
+
+- Every PR review provisions an ephemeral E2B sandbox (`@e2b/sandbox`) managed by `apps/worker`.
+- The sandbox clones the repository, checks out the PR branch, executes `tsc` / linters / unit tests, runs a structured 4-pillar AI review prompt (Security, Bugs, Architecture, Performance), and self-terminates (`sandbox.kill()`) immediately upon completion (hard timeout: 5 minutes).
+- Diff size limit: PRs exceeding 5,000 changed lines are rejected with a `400 Bad Request` error.
+
+### 2. Normalized Domain Data Model (`PrReview` & `PrReviewComment`)
+
+- `PrReview` (parent): Tracks `id`, `prUrl`, `repoOwner`, `repoName`, `prNumber`, `commitSha`, `status` (`PENDING`, `COMPLETED`, `FAILED`, `CLOSED`, `MERGED`), `summary`, `reviewEvent` (`COMMENT`), `e2bSandboxId`, `sessionId`, `userId`, `createdAt`.
+- `PrReviewComment` (child): Tracks `id`, `reviewId`, `filePath`, `line`, `side`, `body`, `suggestion`, `githubCommentId`, `status` (`OPEN`, `FIXED`, `IGNORED`).
+
+### 3. GitHub App Authentication (`@december-bot`)
+
+- `apps/server` authenticates as `@december-bot` via `@octokit/auth-app` (`GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`).
+- Validates repository installation before starting review. If missing, prompts user with a 1-click GitHub App installation URL (`https://github.com/apps/december-bot/installations/new`).
+
+### 4. Inline Comment Constraints & Secret Redaction
+
+- Inline GitHub comments target lines inside diff hunks. Out-of-diff findings are appended to the review summary under `## ⚠️ Related Codebase Observations`.
+- Regex secret scanning redacts detected credentials to `[REDACTED_SECRET]` and posts a high-priority `🚨 Security Alert` comment.
+
+### 5. Context-Dependent "Fix" Workflow
+
+- **From Session Chat**: Appends the review fix prompt directly into the current active session.
+- **From Standalone `/review` Page**: Provisions a new session workspace (`sessionType: "PR_FIX"`), clones the repo, checks out the PR branch, and feeds open `PrReviewComment` items into the agent prompt context.
+
+### 6. Real-Time Streaming & Web UI
+
+- WebSocket event stream (`REVIEW_PROGRESS`, `REVIEW_COMMENT_CREATED`, `REVIEW_COMPLETED`) pushes live findings to `apps/web`.
+- Diff viewer (`/review/:reviewId` & `ReviewPane.tsx`) renders syntax-highlighted code diffs with expandable inline suggestion cards.
+
+### 7. Metering & Billing
+
+- Deducts exact E2B sandbox runtime duration cost plus LLM token usage from the user's credit balance. Enforces rate limits via `RateLimiter`.
+
+## Consequences
+
+- **Security & Integrity**: Code reviews run in clean, isolated E2B microVMs without exposing local host assets or leaking secrets.
+- **Developer Experience**: Native GitHub `suggestion` blocks enable 1-click commit suggestions on GitHub, while the "Fix" button provides instant automated remediation.
+- **Maintainability**: Clear backend module separation (`apps/server/src/modules/review/`) adhering to `AGENTS.md` standards.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -75,10 +75,10 @@ export class Agent {
         this.operations = config.operations
         this.env = new Map<string, string>()
         this.modelOptions = config.modelOptions
-        this.thinkingLevel = config.thinkingLevel || 'off'
+        this.thinkingLevel = config.thinkingLevel || 'medium'
         this.convertToLlm = config.convertToLlm || this.defaultConvertToLlm
-        this.steeringQueue = new PendingMessageQueue(config.steeringMode || 'one-at-a-time')
-        this.followUpQueue = new PendingMessageQueue(config.followUpMode || 'one-at-a-time')
+        this.steeringQueue = new PendingMessageQueue(config.steeringMode || 'all')
+        this.followUpQueue = new PendingMessageQueue(config.followUpMode || 'all')
         this.conversation = new ConversationManager()
 
         for (const tool of config.tools) {

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,7 +1,7 @@
 export * from './types.ts'
 export { registerProvider, getProvider, getAllProviders } from './registry.ts'
 
-export { MODEL_CONTEXT_WINDOWS } from './models.ts'
+export { MODEL_CONTEXT_WINDOWS, getModelContextWindow } from './models.ts'
 export * from './providers/openai.ts'
 export * from './providers/anthropic.ts'
 export * from './providers/gemini.ts'

--- a/packages/providers/src/models.ts
+++ b/packages/providers/src/models.ts
@@ -22,6 +22,27 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
     'deepseek-reasoner': 128000,
 }
 
+export function getModelContextWindow(value: string): number {
+    if (!value) return 100000
+    if (MODEL_CONTEXT_WINDOWS[value]) {
+        return MODEL_CONTEXT_WINDOWS[value]
+    }
+    const lower = value.toLowerCase()
+    if (lower.includes('gemini')) return 1000000
+    if (lower.includes('claude')) return 200000
+    if (lower.includes('o3-mini') || lower.includes('o1')) return 200000
+    if (lower.includes('gpt-4.5')) return 128000
+    if (lower.includes('gpt-4')) return 128000
+    if (lower.includes('gpt-3.5')) return 16385
+    if (lower.includes('deepseek')) return 128000
+    if (lower.includes('llama-3.3') || lower.includes('llama-3.1')) return 128000
+    if (lower.includes('128k')) return 131072
+    if (lower.includes('32k')) return 32768
+    if (lower.includes('8192')) return 8192
+    if (lower.includes('8k')) return 8192
+    return 100000
+}
+
 export interface ProviderConfig<T> {
     id: string
     name: string

--- a/packages/providers/src/providers/anthropic.ts
+++ b/packages/providers/src/providers/anthropic.ts
@@ -70,6 +70,24 @@ export function anthropicProvider(baseURL?: string, apiKey?: string): LLMProvide
                 input_schema: t.inputSchema,
             }))
 
+            const thinkingLevel = modelOptions?.thinkingLevel
+            let thinking: { type: 'enabled'; budget_tokens: number } | undefined
+            let maxTokens = modelOptions?.max_tokens || 4096
+
+            if (thinkingLevel && thinkingLevel !== 'off') {
+                const budgetMap: Record<string, number> = {
+                    minimal: 1024,
+                    low: 2048,
+                    medium: 4096,
+                    high: 8192,
+                }
+                const budget = budgetMap[thinkingLevel]
+                if (budget) {
+                    thinking = { type: 'enabled', budget_tokens: budget }
+                    maxTokens = Math.max(maxTokens, budget + 1024)
+                }
+            }
+
             const stream = await client.messages.create(
                 {
                     model: modelOptions?.model || 'claude-3-5-sonnet-20241022',
@@ -77,8 +95,9 @@ export function anthropicProvider(baseURL?: string, apiKey?: string): LLMProvide
                     system: systemPrompt,
                     tools: antTools,
                     stream: true,
-                    max_tokens: modelOptions?.max_tokens || 4096,
-                    temperature: modelOptions?.temperature,
+                    max_tokens: maxTokens,
+                    temperature: thinking ? undefined : modelOptions?.temperature,
+                    thinking: thinking as any,
                 },
                 { signal }
             )
@@ -108,6 +127,8 @@ export function anthropicProvider(baseURL?: string, apiKey?: string): LLMProvide
                 } else if (event.type === 'content_block_delta') {
                     if (event.delta.type === 'text_delta') {
                         yield { type: 'text', text: event.delta.text }
+                    } else if (event.delta.type === 'thinking_delta') {
+                        yield { type: 'thinking_delta', text: (event.delta as any).thinking }
                     } else if (event.delta.type === 'input_json_delta') {
                         const id = activeToolCalls.get(event.index)
                         if (id) {

--- a/packages/providers/src/providers/gemini.ts
+++ b/packages/providers/src/providers/gemini.ts
@@ -165,6 +165,21 @@ export function geminiProvider(apiKey?: string): LLMProvider {
                   ]
                 : undefined
 
+            const thinkingLevel = modelOptions?.thinkingLevel
+            let thinkingConfig: { thinkingBudget?: number } | undefined
+            if (thinkingLevel && thinkingLevel !== 'off') {
+                const budgetMap: Record<string, number> = {
+                    minimal: 1024,
+                    low: 2048,
+                    medium: 4096,
+                    high: 8192,
+                }
+                const budget = budgetMap[thinkingLevel]
+                if (budget) {
+                    thinkingConfig = { thinkingBudget: budget }
+                }
+            }
+
             const responseStream = await (client.models.generateContentStream as any)({
                 model: modelOptions?.model || 'gemini-3.6-flash',
                 contents: geminiMessages,
@@ -175,6 +190,7 @@ export function geminiProvider(apiKey?: string): LLMProvider {
                     tools: geminiTools,
                     temperature: modelOptions?.temperature,
                     maxOutputTokens: modelOptions?.max_tokens,
+                    thinkingConfig,
                 },
                 abortSignal: signal,
             })

--- a/packages/providers/src/providers/openai.ts
+++ b/packages/providers/src/providers/openai.ts
@@ -74,6 +74,18 @@ export function openaiProvider(
                 },
             }))
 
+            const thinkingLevel = modelOptions?.thinkingLevel
+            let reasoningEffort: 'low' | 'medium' | 'high' | undefined
+            if (thinkingLevel && thinkingLevel !== 'off') {
+                if (thinkingLevel === 'minimal' || thinkingLevel === 'low') {
+                    reasoningEffort = 'low'
+                } else if (thinkingLevel === 'medium') {
+                    reasoningEffort = 'medium'
+                } else if (thinkingLevel === 'high') {
+                    reasoningEffort = 'high'
+                }
+            }
+
             const stream = await client.chat.completions.create(
                 {
                     model: modelOptions?.model || 'gpt-4o',
@@ -82,6 +94,7 @@ export function openaiProvider(
                     stream: true,
                     temperature: modelOptions?.temperature,
                     max_tokens: modelOptions?.max_tokens,
+                    reasoning_effort: reasoningEffort,
                     stream_options: { include_usage: true },
                 },
                 { signal }

--- a/packages/providers/test/integration/anthropic.integration.test.ts
+++ b/packages/providers/test/integration/anthropic.integration.test.ts
@@ -142,4 +142,18 @@ describe('Anthropic Provider (Integration)', () => {
         expect(provider.id).toBe('anthropic')
         expect(provider.stream).toBeInstanceOf(Function)
     })
+
+    test('should map thinkingLevel to thinking budget_tokens and max_tokens', async () => {
+        const provider = anthropicProvider('test-key')
+        const gen = provider.stream([{ role: 'user', content: 'hello' }], undefined, undefined, {
+            thinkingLevel: 'high',
+        })
+
+        const it = gen[Symbol.asyncIterator]()
+        await it.next()
+
+        expect(capturedOptions).not.toBeNull()
+        expect(capturedOptions.thinking).toEqual({ type: 'enabled', budget_tokens: 8192 })
+        expect(capturedOptions.max_tokens).toBe(9216)
+    })
 })

--- a/packages/providers/test/integration/openai.integration.test.ts
+++ b/packages/providers/test/integration/openai.integration.test.ts
@@ -129,4 +129,17 @@ describe('OpenAI Provider (Integration)', () => {
         expect(provider.id).toBe('openai')
         expect(provider.stream).toBeInstanceOf(Function)
     })
+
+    test('should map thinkingLevel to reasoning_effort', async () => {
+        const provider = openaiProvider('test-key')
+        const gen = provider.stream([{ role: 'user', content: 'hello' }], undefined, undefined, {
+            thinkingLevel: 'medium',
+        })
+
+        const it = gen[Symbol.asyncIterator]()
+        await it.next()
+
+        expect(capturedOptions).not.toBeNull()
+        expect(capturedOptions.reasoning_effort).toBe('medium')
+    })
 })

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 export const env = createEnv({
     server: {
-        NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+        ENV: z.enum(['DEV', 'TEST', 'PROD']).default('DEV'),
         PORT: z.coerce.number().default(3000),
         LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
 

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -22,6 +22,7 @@
         "typescript": "^5"
     },
     "dependencies": {
+        "@december/providers": "workspace:*",
         "@december/shared": "workspace:*",
         "cli-highlight": "2.1.11",
         "ink": "^7.0.5",

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -91,7 +91,7 @@ export function ChatApp({
     return (
         <Box flexDirection="column" width="100%">
             <GlobalShortcuts {...session} agent={agent} />
-            <TaskHUD cwd={process.cwd()} />
+            <TaskHUD cwd={process.cwd()} showTasks={session.settingsShowTasks} />
             <MessageList
                 staticKey={staticKey}
                 staticMessages={staticMessages}

--- a/packages/tui/src/components/command-menu/commands.tsx
+++ b/packages/tui/src/components/command-menu/commands.tsx
@@ -137,7 +137,7 @@ export const COMMANDS: Command[] = [
 
                 ctx.toast.show({ variant: 'info', message: 'Requesting upload URL...' })
 
-                const serverUrl = process.env.DECEMBER_SERVER_URL || 'https://api.trydecember.com'
+                const serverUrl = process.env.SERVER_URL || 'https://api.trydecember.com'
                 const proxyUrl = `${serverUrl}/api/v1`
                 const urlRes = await fetch(`${proxyUrl}/cli/handoff/upload-url`, {
                     headers: { Authorization: `Bearer ${config.decemberToken}` },

--- a/packages/tui/src/components/command-menu/commands.tsx
+++ b/packages/tui/src/components/command-menu/commands.tsx
@@ -202,20 +202,9 @@ export const COMMANDS: Command[] = [
                 const skillsFile = path.join(decDir, 'skills.md')
                 const mcpFile = path.join(decDir, 'mcp.json')
 
-                fs.writeFileSync(
-                    agentsFile,
-                    '# AGENTS.md\n\nWelcome to December workspace instructions. December automatically loads project context, coding rules, and available agent skills from `.december/`.\n'
-                )
-
-                fs.writeFileSync(
-                    rulesFile,
-                    '# Rules\n\n- **Code Quality**: Ensure all functions have proper TypeScript typing and descriptive parameter names.\n- **Error Handling**: Never use empty catch blocks; always handle or explicitly log exceptions.\n- **Testing**: Write unit or integration tests for new services and run test suites before submitting changes.\n- **Architecture**: Keep business logic inside service modules and delegate HTTP request parsing to controllers.\n'
-                )
-
-                fs.writeFileSync(
-                    skillsFile,
-                    '# Skills\n\n- **Code Review**: Autonomous code review checking coding standards and architectural requirements.\n- **Refactoring**: Step-by-step code refactoring with incremental safety checks and clean commits.\n- **Bug Diagnosis**: Systematic root cause investigation using log tracebacks and regression tests.\n- **Test Generation**: Automated generation of unit and integration test suites using red-green-refactor patterns.\n'
-                )
+                fs.writeFileSync(agentsFile, '# AGENTS.md\n')
+                fs.writeFileSync(rulesFile, '# Rules\n')
+                fs.writeFileSync(skillsFile, '# Skills\n')
 
                 fs.writeFileSync(
                     mcpFile,

--- a/packages/tui/src/components/global-shortcuts.tsx
+++ b/packages/tui/src/components/global-shortcuts.tsx
@@ -13,6 +13,8 @@ export function GlobalShortcuts(session: any) {
         setTaskViewingId,
         taskScrollOffset,
         setTaskScrollOffset,
+        taskSelectedIndex,
+        setTaskSelectedIndex,
         sessionRenameMode,
         setSessionRenameMode,
         customInputMode,
@@ -21,13 +23,13 @@ export function GlobalShortcuts(session: any) {
         setPlanMode,
         grillMode,
         setGrillMode,
-        grillQuestions,
         setGrillQuestions,
         setCurrentGrillIndex,
         setGrillAnswers,
         setGrillPrompt,
         setCurrentPlannedPrompt,
         tasksData,
+        handleKillTask,
     } = session
 
     useInput((input, key) => {
@@ -39,10 +41,31 @@ export function GlobalShortcuts(session: any) {
                 } else {
                     setAuthMode('none')
                 }
+            } else if (taskViewingId) {
+                if (key.upArrow) setTaskScrollOffset((prev: number) => Math.max(0, prev - 1))
+                if (key.downArrow) setTaskScrollOffset((prev: number) => prev + 1)
+                if (key.leftArrow) setTaskScrollOffset((prev: number) => Math.max(0, prev - 10))
+                if (key.rightArrow) setTaskScrollOffset((prev: number) => prev + 10)
+            } else {
+                if (key.upArrow) setTaskSelectedIndex((prev: number) => Math.max(0, prev - 1))
+                if (key.downArrow)
+                    setTaskSelectedIndex((prev: number) =>
+                        Math.min(Math.max(0, (tasksData?.length || 1) - 1), prev + 1)
+                    )
+                if (key.return) {
+                    const selected = tasksData?.[taskSelectedIndex]
+                    if (selected) {
+                        setTaskViewingId(selected.id)
+                        setTaskScrollOffset(0)
+                    }
+                }
+                if (input === 'k' || input === 'K') {
+                    const selected = tasksData?.[taskSelectedIndex]
+                    if (selected && handleKillTask) {
+                        handleKillTask(selected.id)
+                    }
+                }
             }
-            if (taskViewingId && key.upArrow)
-                setTaskScrollOffset((prev: number) => Math.max(0, prev - 1))
-            if (taskViewingId && key.downArrow) setTaskScrollOffset((prev: number) => prev + 1)
             return
         }
 
@@ -60,7 +83,6 @@ export function GlobalShortcuts(session: any) {
             if (key.escape) {
                 setPlanMode(false)
                 setCurrentPlannedPrompt(null)
-                toast.show({ variant: 'error', message: 'Plan rejected.' })
             }
             return
         }

--- a/packages/tui/src/components/menus/context-select-menu.tsx
+++ b/packages/tui/src/components/menus/context-select-menu.tsx
@@ -1,10 +1,8 @@
+import { getModelContextWindow } from '@december/providers'
 import { Box, Text } from 'ink'
 
 function getModelLabel(id: string) {
     return id
-}
-function getModelContextWindow(id: string) {
-    return 128000
 }
 
 export function ContextSelectMenu(props: any) {

--- a/packages/tui/src/components/menus/settings-main-menu.tsx
+++ b/packages/tui/src/components/menus/settings-main-menu.tsx
@@ -6,11 +6,8 @@ import { CustomIndicator, CustomItem } from './menu-items'
 export function SettingsMainMenu(props: any) {
     const {
         settingsNonWorkspace,
-        settingsNotifications,
         settingsShowTasks,
-        settingsShowTips,
         settingsToolPermission,
-        settingsAutoUpdate,
         settingsThinkingLevel,
         settingsSteeringMode,
         settingsFollowUpMode,
@@ -24,24 +21,12 @@ export function SettingsMainMenu(props: any) {
             value: 'nonWorkspaceAccess',
         },
         {
-            label: `Notifications            [${settingsNotifications ? 'on' : 'off'}]`,
-            value: 'notifications',
-        },
-        {
             label: `Show Active Tasks        [${settingsShowTasks ? 'on' : 'off'}]`,
             value: 'showActiveTasks',
         },
         {
-            label: `Show Tips                [${settingsShowTips ? 'on' : 'off'}]`,
-            value: 'showTips',
-        },
-        {
             label: `Tool Permission          [${settingsToolPermission}]`,
             value: 'toolPermission',
-        },
-        {
-            label: `Auto Update              [${settingsAutoUpdate ? 'on' : 'off'}]`,
-            value: 'autoUpdate',
         },
         {
             label: `Thinking Level           [${settingsThinkingLevel}]`,

--- a/packages/tui/src/components/task-hud.tsx
+++ b/packages/tui/src/components/task-hud.tsx
@@ -4,10 +4,12 @@ import path from 'path'
 import { Box, Text } from 'ink'
 import React, { useState, useEffect } from 'react'
 
-export function TaskHUD({ cwd }: { cwd: string }) {
+export function TaskHUD({ cwd, showTasks = true }: { cwd: string; showTasks?: boolean }) {
     const [taskLines, setTaskLines] = useState<string[]>([])
 
     useEffect(() => {
+        if (!showTasks) return
+
         const taskPath = path.join(cwd, 'task.md')
 
         const updateTasks = () => {
@@ -29,9 +31,9 @@ export function TaskHUD({ cwd }: { cwd: string }) {
         updateTasks()
         const interval = setInterval(updateTasks, 2000)
         return () => clearInterval(interval)
-    }, [cwd])
+    }, [cwd, showTasks])
 
-    if (taskLines.length === 0) return null
+    if (!showTasks || taskLines.length === 0) return null
 
     return (
         <Box

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,7 +22,8 @@
             "@december/database": ["./packages/database/src/index.ts"],
             "@december/agent": ["./packages/agent/src/index.ts"],
             "@december/tui": ["./packages/tui/src/index.tsx"],
-            "@december/shared": ["./packages/shared/src/index.ts"]
+            "@december/shared": ["./packages/shared/src/index.ts"],
+            "@december/providers": ["./packages/providers/src/index.ts"]
         },
 
         "noUnusedLocals": false,


### PR DESCRIPTION
## Summary

Closes #298

- **Pruned Unused Settings**: Completely removed stub settings (`Auto Update`, `Notifications`, `Show Tips`) across `apps/cli` and `packages/tui`.
- **Non-Workspace Access Sandboxing**: Intercepted file tools (`view_file`, `write_to_file`, `replace_file_content`, `multi_replace_file_content`) in `setupAgentInterceptors` to enforce path checks against `process.cwd()` when `nonWorkspaceAccess` is `[off]`.
- **Task HUD Visibility**: Connected `settingsShowTasks` to `<TaskHUD />` in `packages/tui/src/app.tsx`.
- **End-to-End Extended Thinking**: Mapped `thinkingLevel` (`off`, `minimal`, `low`, `medium`, `high`) to provider reasoning options in Anthropic, OpenAI, and Gemini providers, defaulting to `medium`.
- **Interactive Tasks Mode**: Added complete arrow-key navigation, return log inspector, page scroll, and task termination shortcut (`k`) to `/tasks` mode.

## Testing

- Unit tests: `bun test:cli` (126 pass, 0 fail)
- Provider integration tests: `bun test:providers` (30 pass, 1 skip, 0 fail)
- Agent integration tests: `bun test:agent` (36 pass, 0 fail)
- Typecheck: `bun run typecheck` (13 packages successful)