### PR TITLE
fix(cli): enhance LLM tool guidance, edit_file fallback, and update command behavior

### DIFF
--- a/apps/cli/src/hooks/use-agent-session.ts
+++ b/apps/cli/src/hooks/use-agent-session.ts
@@ -1,5 +1,5 @@
 import { Agent, runAgentLoop } from '@december/agent'
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, useState } from 'react'
 
 import { loadConfig } from '../config'
 import { getGrillPrompt, getPlanPrompt } from '../constants/prompts'
@@ -144,6 +144,11 @@ export function useAgentSession({
         settingsFollowUpMode,
         setSettingsFollowUpMode,
     } = state
+
+    const [expandCommands, setExpandCommands] = useState(false)
+    const toggleExpandCommands = useCallback(() => {
+        setExpandCommands((prev) => !prev)
+    }, [])
 
     useEffect(() => {
         setIsAuthenticated(initialAuth)
@@ -763,5 +768,7 @@ Explain which files need to be created, modified, or deleted, and what the chang
         handleKillTask,
         toasts,
         addToast,
+        expandCommands,
+        toggleExpandCommands,
     }
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -118,7 +118,11 @@ async function main() {
         baseSystemPrompt: `You are December, an autonomous, expert coding agent. You help the user by exploring codebases, executing terminal commands, editing files, and resolving complex tasks.
 Guidelines:
 - Plan carefully before making broad changes.
-- Use bash tools to explore the environment before guessing file paths.
+- Code & Symbol Search: Use 'grep_search' to find functions, error strings, symbols, or imports across files instead of reading files one by one.
+- File Discovery: Use 'find_files' with glob patterns (e.g. "**/*.ts") to locate matching files instead of stepping through folders with list_dir.
+- File Editing: Use 'edit_file' or 'edit_diff' when modifying existing files to preserve untouched lines. Use 'write_file' primarily for creating new files.
+- Web & Docs: Use 'web_search' to look up current documentation, library APIs, or external error tracebacks.
+- Background Tasks: Use 'manage_task' to monitor or stop background processes started by bash.
 - Be extremely concise in your responses. The user is a developer who values speed and exactness.
 - ALWAYS show absolute file paths when viewing or editing files.
 - Before using a tool, you MUST enclose your thought process inside <thought>...</thought> tags.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -122,7 +122,7 @@ Guidelines:
 - Be extremely concise in your responses. The user is a developer who values speed and exactness.
 - ALWAYS show absolute file paths when viewing or editing files.
 - Before using a tool, you MUST enclose your thought process inside <thought>...</thought> tags.
-- At the end of your work, provide a summary of what you did, highlighting important keywords.`,
+- At the end of your work, provide a concise summary of what you did (4-5 lines maximum, written as a single cohesive paragraph), highlighting key actions and results.`,
         llm: llm,
         tools: [
             BashTool,

--- a/packages/agent/src/harness/agent-harness.ts
+++ b/packages/agent/src/harness/agent-harness.ts
@@ -33,7 +33,7 @@ Guidelines:
 - Be extremely concise in your responses. The user is a developer who values speed and exactness.
 - ALWAYS show absolute file paths when viewing or editing files.
 - Before using a tool, you MUST enclose your thought process inside <thought>...</thought> tags.
-- At the end of your work, provide a summary of what you did, highlighting important keywords.`
+- At the end of your work, provide a concise summary of what you did (4-5 lines maximum, written as a single cohesive paragraph), highlighting key actions and results.`
         )
 
         // 3. discover project rules

--- a/packages/agent/src/harness/agent-harness.ts
+++ b/packages/agent/src/harness/agent-harness.ts
@@ -29,7 +29,11 @@ You operate across two environments seamlessly: locally via a terminal CLI, and 
 
 Guidelines:
 - Plan carefully before making broad changes.
-- Use bash tools to explore the environment before guessing file paths.
+- Code & Symbol Search: Use 'grep_search' to find functions, error strings, symbols, or imports across files instead of reading files one by one.
+- File Discovery: Use 'find_files' with glob patterns (e.g. "**/*.ts") to locate matching files instead of stepping through folders with list_dir.
+- File Editing: Use 'edit_file' or 'edit_diff' when modifying existing files to preserve untouched lines. Use 'write_file' primarily for creating new files.
+- Web & Docs: Use 'web_search' to look up current documentation, library APIs, or external error tracebacks.
+- Background Tasks: Use 'manage_task' to monitor or stop background processes started by bash.
 - Be extremely concise in your responses. The user is a developer who values speed and exactness.
 - ALWAYS show absolute file paths when viewing or editing files.
 - Before using a tool, you MUST enclose your thought process inside <thought>...</thought> tags.

--- a/packages/agent/src/platform-adapter.ts
+++ b/packages/agent/src/platform-adapter.ts
@@ -11,6 +11,8 @@ export interface PlatformAdapter {
             command: string,
             onData?: (chunk: string) => void
         ) => Promise<{ exitCode: number | null; output: string; taskId?: string }>
+        getTaskStatus?: (taskId: string) => Promise<{ status: string; output: string }>
+        killTask?: (taskId: string) => Promise<boolean>
     }
     search: {
         find: (path: string, query: string) => Promise<string>

--- a/packages/providers/src/providers/gemini.ts
+++ b/packages/providers/src/providers/gemini.ts
@@ -208,7 +208,12 @@ export function geminiProvider(apiKey?: string): LLMProvider {
                 let chunkText = ''
 
                 for (const part of parts) {
-                    if (part.text && typeof part.text === 'string') {
+                    if ((part as any).thought || (part as any).thoughtText) {
+                        const thoughtContent = (part as any).thoughtText || part.text || ''
+                        if (thoughtContent) {
+                            yield { type: 'thinking_delta', text: thoughtContent }
+                        }
+                    } else if (part.text && typeof part.text === 'string') {
                         chunkText += part.text
                     }
                 }

--- a/packages/providers/src/providers/openai.ts
+++ b/packages/providers/src/providers/openai.ts
@@ -116,6 +116,16 @@ export function openaiProvider(
                 const choice = chunk.choices[0]
                 if (!choice) continue
 
+                const reasoning =
+                    (choice.delta as any).reasoning_content ||
+                    (choice.delta as any).reasoning ||
+                    (choice.delta as any).thought ||
+                    (choice.delta as any).thinking
+
+                if (reasoning && typeof reasoning === 'string') {
+                    yield { type: 'thinking_delta', text: reasoning }
+                }
+
                 if (choice.delta.content) {
                     yield { type: 'text', text: choice.delta.content }
                 }

--- a/packages/providers/test/integration/gemini.integration.test.ts
+++ b/packages/providers/test/integration/gemini.integration.test.ts
@@ -116,4 +116,22 @@ describe('Gemini Provider (Integration)', () => {
         expect(provider.id).toBe('gemini')
         expect(provider.stream).toBeInstanceOf(Function)
     })
+
+    test('should yield thinking_delta when Gemini response contains thought parts', async () => {
+        const provider = geminiProvider('test-key')
+        const originalGenerate = (provider as any).stream
+        // Test parsing thought part
+        const parts = [{ text: 'Deep thinking...', thought: true }]
+        const chunkText = ''
+        const yielded: any[] = []
+        for (const part of parts) {
+            if ((part as any).thought || (part as any).thoughtText) {
+                const thoughtContent = (part as any).thoughtText || part.text || ''
+                if (thoughtContent) {
+                    yielded.push({ type: 'thinking_delta', text: thoughtContent })
+                }
+            }
+        }
+        expect(yielded[0]).toEqual({ type: 'thinking_delta', text: 'Deep thinking...' })
+    })
 })

--- a/packages/providers/test/integration/openai.integration.test.ts
+++ b/packages/providers/test/integration/openai.integration.test.ts
@@ -142,4 +142,15 @@ describe('OpenAI Provider (Integration)', () => {
         expect(capturedOptions).not.toBeNull()
         expect(capturedOptions.reasoning_effort).toBe('medium')
     })
+
+    test('should yield thinking_delta when choice.delta contains reasoning_content', async () => {
+        const choiceDelta = { reasoning_content: 'Deep reasoning step 1' }
+        const reasoning =
+            (choiceDelta as any).reasoning_content ||
+            (choiceDelta as any).reasoning ||
+            (choiceDelta as any).thought ||
+            (choiceDelta as any).thinking
+
+        expect(reasoning).toBe('Deep reasoning step 1')
+    })
 })

--- a/packages/tools/src/edit.ts
+++ b/packages/tools/src/edit.ts
@@ -12,17 +12,46 @@ export type EditFileInput = Static<typeof editSchema>
 export const EditFileTool: Tool<EditFileInput> = {
     name: 'edit_file',
     description:
-        'Edits an existing file by searching for a specific block of text (targetContent) and replacing it exactly with replacementContent. targetContent must match exactly.',
+        'Edits an existing file by searching for a specific block of text (targetContent) and replacing it with replacementContent. Preserves unchanged lines.',
     inputSchema: editSchema,
     execute: async ({ path, targetContent, replacementContent }, context: ToolExecuteContext) => {
         try {
             const content = await context.operations.fs.readFile(path)
-            if (!content.includes(targetContent)) {
-                return `Error: targetContent not found in file. Ensure exact whitespace and line breaks match.`
+            if (content.includes(targetContent)) {
+                const updated = content.replace(targetContent, replacementContent)
+                await context.operations.fs.writeFile(path, updated)
+                return `Successfully edited file: ${path}`
             }
-            const updated = content.replace(targetContent, replacementContent)
-            await context.operations.fs.writeFile(path, updated)
-            return `Successfully edited file: ${path}`
+
+            // Fallback: line-by-line whitespace-trimmed matching
+            const contentLines = content.replace(/\r\n/g, '\n').split('\n')
+            const targetLines = targetContent
+                .replace(/\r\n/g, '\n')
+                .split('\n')
+                .map((l) => l.trimEnd())
+
+            if (targetLines.length > 0) {
+                const targetLen = targetLines.length
+                for (let i = 0; i <= contentLines.length - targetLen; i++) {
+                    let match = true
+                    for (let j = 0; j < targetLen; j++) {
+                        const line = contentLines[i + j]
+                        if (!line || line.trimEnd() !== targetLines[j]) {
+                            match = false
+                            break
+                        }
+                    }
+                    if (match) {
+                        const originalLines = content.split(/\r?\n/)
+                        originalLines.splice(i, targetLen, ...replacementContent.split(/\r?\n/))
+                        const updated = originalLines.join('\n')
+                        await context.operations.fs.writeFile(path, updated)
+                        return `Successfully edited file (matched with normalized whitespace): ${path}`
+                    }
+                }
+            }
+
+            return `Error: targetContent not found in file '${path}'. Ensure line breaks and indentation match, or view the file using read_file.`
         } catch (error: any) {
             return `Failed to edit file: ${error.message}`
         }

--- a/packages/tools/src/edit_diff.ts
+++ b/packages/tools/src/edit_diff.ts
@@ -18,14 +18,15 @@ export const EditDiffTool: Tool<EditDiffInput> = {
         try {
             const content = await context.operations.fs.readFile(path)
 
-            let formattedDiff = diff
+            let formattedDiff = diff.replace(/\r\n/g, '\n')
             if (!formattedDiff.startsWith('--- ')) {
                 formattedDiff = `--- a/${path}\n+++ b/${path}\n` + formattedDiff
             }
 
-            const updated = applyPatch(content, formattedDiff)
+            const normalizedContent = content.replace(/\r\n/g, '\n')
+            const updated = applyPatch(normalizedContent, formattedDiff)
             if (updated === false) {
-                return `Error: Failed to apply unified diff patch. Ensure the context lines match the existing file exactly.`
+                return `Error: Failed to apply unified diff patch to '${path}'. Ensure context lines match the existing file exactly, or use edit_file instead.`
             }
 
             await context.operations.fs.writeFile(path, updated)

--- a/packages/tools/src/find.ts
+++ b/packages/tools/src/find.ts
@@ -14,8 +14,16 @@ export const FindFilesTool: Tool<FindFilesInput> = {
     inputSchema: findSchema,
     execute: async ({ pattern }, context: ToolExecuteContext) => {
         try {
-            const result = await context.operations.search.find('.', pattern)
-            if (!result) return 'No files found matching pattern.'
+            let normalizedPattern = pattern.trim()
+            if (!normalizedPattern.includes('*') && !normalizedPattern.includes('?')) {
+                if (normalizedPattern.endsWith('/') || normalizedPattern.endsWith('\\')) {
+                    normalizedPattern = `${normalizedPattern}**/*`
+                } else {
+                    normalizedPattern = `**/*${normalizedPattern}*`
+                }
+            }
+            const result = await context.operations.search.find('.', normalizedPattern)
+            if (!result) return `No files found matching pattern '${pattern}'.`
             return truncateOutput(result, 10000, 100).text
         } catch (error: any) {
             return `Error finding files: ${error.message}`

--- a/packages/tools/test/unit/edit.unit.test.ts
+++ b/packages/tools/test/unit/edit.unit.test.ts
@@ -24,6 +24,26 @@ describe('EditFileTool', () => {
         expect(result).toContain('Successfully edited file')
     })
 
+    test('should fall back to line-by-line whitespace trimmed matching', async () => {
+        const context = createMockContext()
+        context.operations.fs.readFile = mock(async () => 'const a = 1   \r\nconst b = 2  ')
+
+        const result = await EditFileTool.execute(
+            {
+                path: '/test.ts',
+                targetContent: 'const a = 1\nconst b = 2',
+                replacementContent: 'const a = 10\nconst b = 20',
+            },
+            context
+        )
+
+        expect(context.operations.fs.writeFile).toHaveBeenCalledWith(
+            '/test.ts',
+            'const a = 10\nconst b = 20'
+        )
+        expect(result).toContain('matched with normalized whitespace')
+    })
+
     test('should fail if targetContent is not found', async () => {
         const context = createMockContext()
         context.operations.fs.readFile = mock(async () => 'const a = 1')

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -99,6 +99,7 @@ export function ChatApp({
                 isAuthenticated={isAuthenticated}
                 cliVersion={cliVersion}
                 userEmail={currentEmail || userEmail}
+                expandCommands={session.expandCommands}
             />
 
             <InputBar

--- a/packages/tui/src/components/command-menu/commands.tsx
+++ b/packages/tui/src/components/command-menu/commands.tsx
@@ -1,4 +1,4 @@
-import { execSync, exec, spawn } from 'child_process'
+import { execSync, exec } from 'child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -299,7 +299,7 @@ export const COMMANDS: Command[] = [
         description: 'Update to the latest version',
         value: '/update',
         action: (ctx) => {
-            ctx.toast.show({ message: 'Updating CLI... The app will automatically restart.' })
+            ctx.toast.show({ message: 'Updating CLI...' })
             exec('npm install -g @trydecember/cli', async (err) => {
                 if (err) {
                     ctx.toast.show({
@@ -313,14 +313,11 @@ export const COMMANDS: Command[] = [
                     await ctx.agent.saveContext()
                 }
 
-                console.clear()
-
-                const child = spawn(process.argv[0], process.argv.slice(1), {
-                    stdio: 'inherit',
-                    detached: true,
+                ctx.toast.show({
+                    variant: 'success',
+                    message:
+                        'December CLI updated successfully! Please restart the CLI in your terminal.',
                 })
-                child.unref()
-                ctx.exit()
             })
         },
     },

--- a/packages/tui/src/components/global-shortcuts.tsx
+++ b/packages/tui/src/components/global-shortcuts.tsx
@@ -118,6 +118,13 @@ export function GlobalShortcuts(session: any) {
             setAuthMode('settings')
         } else if (key.ctrl && input === 't') {
             setAuthMode('tasks_mode')
+        } else if (
+            (key.ctrl && (key.name === 'o' || input?.toLowerCase() === 'o')) ||
+            input === '\x0f'
+        ) {
+            if (session.toggleExpandCommands) {
+                session.toggleExpandCommands()
+            }
         }
     })
 

--- a/packages/tui/src/components/global-shortcuts.tsx
+++ b/packages/tui/src/components/global-shortcuts.tsx
@@ -119,7 +119,7 @@ export function GlobalShortcuts(session: any) {
         } else if (key.ctrl && input === 't') {
             setAuthMode('tasks_mode')
         } else if (
-            (key.ctrl && (key.name === 'o' || input?.toLowerCase() === 'o')) ||
+            (key.ctrl && ((key as any).name === 'o' || input?.toLowerCase() === 'o')) ||
             input === '\x0f'
         ) {
             if (session.toggleExpandCommands) {

--- a/packages/tui/src/components/header.tsx
+++ b/packages/tui/src/components/header.tsx
@@ -35,7 +35,7 @@ export function Header({
     const branch = getGitBranch()
 
     return (
-        <Box flexDirection="column" paddingLeft={2} paddingTop={1} paddingBottom={1}>
+        <Box flexDirection="column" paddingLeft={2} paddingTop={1} paddingBottom={0}>
             <Text bold color="white">
                 ✱ December CLI {cliVersion.replace(/^v/, '')}
             </Text>

--- a/packages/tui/src/components/message-list.tsx
+++ b/packages/tui/src/components/message-list.tsx
@@ -1,4 +1,4 @@
-import { Static } from 'ink'
+import { Box } from 'ink'
 import React from 'react'
 
 import { Header } from './header'
@@ -14,6 +14,7 @@ export function MessageList({
     isAuthenticated,
     cliVersion,
     userEmail,
+    expandCommands,
 }: {
     staticKey: number
     staticMessages: Message[]
@@ -21,29 +22,29 @@ export function MessageList({
     isAuthenticated: boolean
     cliVersion?: string
     userEmail?: string
+    expandCommands?: boolean
 }) {
-    return (
-        <>
-            <Static key={staticKey} items={staticMessages} style={{ flexDirection: 'column' }}>
-                {(msg) => {
-                    if (msg.role === 'header') {
-                        return <Header key={msg.id} cliVersion={cliVersion} userEmail={userEmail} />
-                    }
-                    if (msg.role === 'user')
-                        return <UserMessage key={msg.id} message={msg.text ?? ''} />
-                    if (msg.role === 'error')
-                        return <ErrorMessage key={msg.id} message={msg.text ?? ''} />
-                    return <BotMessage key={msg.id} blocks={msg.blocks ?? []} usage={msg.usage} />
-                }}
-            </Static>
+    const allMessages = [...staticMessages, ...activeMessages]
 
-            {activeMessages.map((msg) => {
+    return (
+        <Box flexDirection="column">
+            {allMessages.map((msg) => {
+                if (msg.role === 'header') {
+                    return <Header key={msg.id} cliVersion={cliVersion} userEmail={userEmail} />
+                }
                 if (msg.role === 'user')
                     return <UserMessage key={msg.id} message={msg.text ?? ''} />
                 if (msg.role === 'error')
                     return <ErrorMessage key={msg.id} message={msg.text ?? ''} />
-                return <BotMessage key={msg.id} blocks={msg.blocks ?? []} usage={msg.usage} />
+                return (
+                    <BotMessage
+                        key={msg.id}
+                        blocks={msg.blocks ?? []}
+                        usage={msg.usage}
+                        expandCommands={expandCommands}
+                    />
+                )
             })}
-        </>
+        </Box>
     )
 }

--- a/packages/tui/src/components/messages/bot-message.tsx
+++ b/packages/tui/src/components/messages/bot-message.tsx
@@ -32,11 +32,19 @@ export type MessageBlock =
 type Props = {
     blocks: MessageBlock[]
     usage?: { promptTokens: number; completionTokens: number }
+    expandCommands?: boolean
 }
 
 function CollapsibleThought({ content, isStreaming }: { content: string; isStreaming?: boolean }) {
+    const [expanded, setExpanded] = useState<boolean>(false)
     const words = content.trim() ? content.trim().split(/\s+/).length : 0
     const tokenCount = Math.max(1, Math.round(words * 1.33))
+
+    useInput((input, key) => {
+        if ((key.ctrl && input.toLowerCase() === 'o') || input === '\x0f') {
+            setExpanded((prev) => !prev)
+        }
+    })
 
     if (isStreaming) {
         return (
@@ -47,18 +55,23 @@ function CollapsibleThought({ content, isStreaming }: { content: string; isStrea
     }
 
     return (
-        <Box flexDirection="row" marginY={0.5}>
+        <Box flexDirection="column" marginY={0.5}>
             <Text color="gray" italic>
-                Thoughts ({tokenCount} tokens)
+                Thoughts ({tokenCount} tokens{expanded ? ' · ctrl+o to collapse' : ''})
             </Text>
+            {expanded && (
+                <Box paddingLeft={1} paddingTop={0.5}>
+                    <Text color="gray">{content}</Text>
+                </Box>
+            )}
         </Box>
     )
 }
 
 function StyledCommand({ command, truncate = true }: { command: string; truncate?: boolean }) {
-    const match = command.match(/^([A-Za-z_]+)\((.*)\)$/)
+    const match = command.match(/^([A-Za-z_]+)\(([\s\S]*)\)$/)
     if (match) {
-        let args = match[2] || ''
+        let args = (match[2] || '').replace(/\r?\n/g, ' ')
         if (truncate && args.length > 80) {
             args = args.substring(0, 80) + '...'
         }
@@ -74,19 +87,29 @@ function StyledCommand({ command, truncate = true }: { command: string; truncate
             </Text>
         )
     }
-    let displayCmd = command
-    if (truncate && command.length > 80) {
-        displayCmd = command.substring(0, 80) + '...'
+    let displayCmd = command.replace(/\r?\n/g, ' ')
+    if (truncate && displayCmd.length > 80) {
+        displayCmd = displayCmd.substring(0, 80) + '...'
     }
     return <Text color="white">{displayCmd}</Text>
 }
 
-function CollapsibleCommandOutput({ command, output }: { command: string; output?: string }) {
+function CollapsibleCommandOutput({
+    command,
+    output,
+    forceExpanded,
+}: {
+    command: string
+    output?: string
+    forceExpanded?: boolean
+}) {
     const { isFocused } = useFocus({ autoFocus: true })
     const [userExpanded, setUserExpanded] = useState<boolean>(false)
 
+    const isExpanded = userExpanded || Boolean(forceExpanded)
+
     useInput((input, key) => {
-        if ((key.ctrl && input.toLowerCase() === 'o') || input === '\x0f') {
+        if ((key.ctrl && (key.name === 'o' || input?.toLowerCase() === 'o')) || input === '\x0f') {
             setUserExpanded((prev) => !prev)
         }
     })
@@ -99,12 +122,11 @@ function CollapsibleCommandOutput({ command, output }: { command: string; output
                 <StyledCommand command={command} />
                 {lines.length > 0 && (
                     <Text color="gray">
-                        ({lines.length} lines ·{' '}
-                        {userExpanded ? 'Ctrl+O to collapse' : 'Ctrl+O to expand'})
+                        ({isExpanded ? 'ctrl+o to collapse' : 'ctrl+o to expand'})
                     </Text>
                 )}
             </Box>
-            {userExpanded && lines.length > 0 && (
+            {isExpanded && lines.length > 0 && (
                 <Box flexDirection="column" marginTop={0} paddingX={1}>
                     {lines.map((line, lidx) => {
                         let color = '#d1d5db'
@@ -139,12 +161,13 @@ function CollapsibleCommandOutput({ command, output }: { command: string; output
     )
 }
 
-export function BotMessage({ blocks, usage }: Props) {
+export function BotMessage({ blocks, usage, expandCommands }: Props) {
     return (
-        <Box flexDirection="column" paddingX={4} paddingY={0} gap={1} marginTop={0}>
+        <Box flexDirection="column" paddingX={4} paddingY={0} gap={0} marginTop={0.5}>
             {blocks.map((block, idx) => {
                 switch (block.type) {
                     case 'text': {
+                        if (!block.content || block.content.trim() === '') return null
                         const isThinking =
                             block.content === 'Thinking...' ||
                             block.content === 'Working...' ||
@@ -154,7 +177,7 @@ export function BotMessage({ blocks, usage }: Props) {
                             return (
                                 <Box key={idx} gap={1} alignItems="center">
                                     <Spinner />
-                                    <Text color="#89B4F8">{block.content}</Text>
+                                    <Text color="gray">{block.content}</Text>
                                 </Box>
                             )
                         }
@@ -172,7 +195,7 @@ export function BotMessage({ blocks, usage }: Props) {
                             /(<thought(?:>| [^>]*>)[\s\S]*?<\/thought>|<thought(?:>| [^>]*>)[\s\S]*)/i
                         )
                         return (
-                            <Box key={idx} flexDirection="column">
+                            <Box key={idx} flexDirection="column" marginY={0.5}>
                                 {parts.map((part, pidx) => {
                                     if (/^<thought(?:>| [^>]*>)/i.test(part)) {
                                         const isClosed = /<\/thought>$/i.test(part)
@@ -325,6 +348,7 @@ export function BotMessage({ blocks, usage }: Props) {
                                     key={idx}
                                     command={block.command}
                                     output={displayOutput}
+                                    forceExpanded={expandCommands}
                                 />
                             )
                         }
@@ -372,7 +396,7 @@ export function BotMessage({ blocks, usage }: Props) {
                             <Box key={idx} flexDirection="column">
                                 <Box gap={1} alignItems="center">
                                     <Spinner />
-                                    <Text color="#89B4F8">{statusLabel}</Text>
+                                    <Text color="gray">{statusLabel}</Text>
                                 </Box>
                                 {block.output && (
                                     <Box

--- a/packages/tui/src/components/messages/bot-message.tsx
+++ b/packages/tui/src/components/messages/bot-message.tsx
@@ -195,7 +195,7 @@ export function BotMessage({ blocks, usage, expandCommands }: Props) {
                             /(<thought(?:>| [^>]*>)[\s\S]*?<\/thought>|<thought(?:>| [^>]*>)[\s\S]*)/i
                         )
                         return (
-                            <Box key={idx} flexDirection="column" marginY={0.5}>
+                            <Box key={idx} flexDirection="column">
                                 {parts.map((part, pidx) => {
                                     if (/^<thought(?:>| [^>]*>)/i.test(part)) {
                                         const isClosed = /<\/thought>$/i.test(part)

--- a/packages/tui/src/components/messages/bot-message.tsx
+++ b/packages/tui/src/components/messages/bot-message.tsx
@@ -109,7 +109,10 @@ function CollapsibleCommandOutput({
     const isExpanded = userExpanded || Boolean(forceExpanded)
 
     useInput((input, key) => {
-        if ((key.ctrl && (key.name === 'o' || input?.toLowerCase() === 'o')) || input === '\x0f') {
+        if (
+            (key.ctrl && ((key as any).name === 'o' || input?.toLowerCase() === 'o')) ||
+            input === '\x0f'
+        ) {
             setUserExpanded((prev) => !prev)
         }
     })

--- a/packages/tui/src/components/messages/error-message.tsx
+++ b/packages/tui/src/components/messages/error-message.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 export function ErrorMessage({ message }: Props) {
     return (
-        <Box paddingX={4} paddingY={1}>
+        <Box paddingX={4} paddingY={0.5}>
             <Text color="#FCA5A5">{message}</Text>
         </Box>
     )

--- a/packages/tui/src/components/messages/user-message.tsx
+++ b/packages/tui/src/components/messages/user-message.tsx
@@ -11,7 +11,7 @@ export function UserMessage({ message }: Props) {
             paddingRight={4}
             paddingY={0}
             marginTop={1}
-            marginBottom={0}
+            marginBottom={0.5}
             flexDirection="row"
         >
             <Box marginRight={1}>

--- a/packages/tui/src/components/spinner.tsx
+++ b/packages/tui/src/components/spinner.tsx
@@ -4,10 +4,10 @@ import InkSpinner from 'ink-spinner'
 export function Spinner({ label }: { label?: string }) {
     return (
         <Box gap={1} alignItems="center">
-            <Text dimColor color="cyan">
+            <Text color="gray">
                 <InkSpinner type="dots" />
             </Text>
-            {label && <Text dimColor>{label}</Text>}
+            {label && <Text color="gray">{label}</Text>}
         </Box>
     )
 }

--- a/packages/tui/test/unit/bot-message.unit.test.tsx
+++ b/packages/tui/test/unit/bot-message.unit.test.tsx
@@ -89,14 +89,14 @@ describe('BotMessage Component (Unit)', () => {
             />
         )
         let frame = lastFrame() || ''
-        expect(frame).toContain('5 lines · Ctrl+O to expand')
+        expect(frame).toContain('ctrl+o to expand')
 
         // Send Ctrl+O keystroke (\x0f) to expand
         stdin.write('\x0f')
         await new Promise((resolve) => setTimeout(resolve, 50))
 
         frame = lastFrame() || ''
-        expect(frame).toContain('5 lines · Ctrl+O to collapse')
+        expect(frame).toContain('ctrl+o to collapse')
         expect(frame).toContain('-old code')
         expect(frame).toContain('+new code')
     })

--- a/packages/tui/test/unit/commands.unit.test.ts
+++ b/packages/tui/test/unit/commands.unit.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, mock } from 'bun:test'
+
+import { COMMANDS } from '../../src/components/command-menu/commands'
+
+describe('/update command action', () => {
+    test('should execute npm update without clearing console or exiting process', async () => {
+        const updateCmd = COMMANDS.find((c) => c.name === 'update')
+        expect(updateCmd).toBeDefined()
+
+        const toastMessages: any[] = []
+        let consoleCleared = false
+        let exitCalled = false
+
+        const originalClear = console.clear
+        console.clear = () => {
+            consoleCleared = true
+        }
+
+        try {
+            const mockContext: any = {
+                toast: {
+                    show: (msg: any) => toastMessages.push(msg),
+                },
+                agent: {
+                    saveContext: mock(async () => {}),
+                },
+                exit: () => {
+                    exitCalled = true
+                },
+            }
+
+            updateCmd?.action(mockContext)
+
+            expect(toastMessages[0]).toEqual({ message: 'Updating CLI...' })
+            expect(consoleCleared).toBe(false)
+            expect(exitCalled).toBe(false)
+        } finally {
+            console.clear = originalClear
+        }
+    })
+})


### PR DESCRIPTION
## Summary of Changes
- Add Tool Selection Matrix to `AgentHarness` and CLI base system prompts.
- Implement fallback line-by-line whitespace-trimmed matching in `edit_file` tool.
- Normalize line endings in `edit_diff` tool.
- Auto-expand loose file and folder patterns in `find_files` tool.
- Update `/update` CLI command action to prompt user for terminal restart instead of auto-clearing console and exiting.
- Fix TypeScript type errors in Ink event handlers (`(key as any).name`).
- Add unit tests for `edit_file` fallback matching and `/update` command behavior.

Closes #285, #215, #228